### PR TITLE
refactor(ids): migrate to int PK + UID contract

### DIFF
--- a/docs/ai/sqlite_int_pk_uid_plan.md
+++ b/docs/ai/sqlite_int_pk_uid_plan.md
@@ -15,15 +15,15 @@
 ## Implementation Checklist
 
 ### 1) Model Layer
-- [ ] Update model identity fields to `ID uint` + `UID string`.
-- [ ] Update `BeforeCreate` hooks to assign `UID` instead of `ID`.
-- [ ] Update relation FK fields to integer IDs where appropriate.
-- [ ] Keep model-specific UID prefixes (`user`, `clnc`, `ptnt`, etc.).
+- [x] Update model identity fields to `ID uint` + `UID string`.
+- [x] Update `BeforeCreate` hooks to assign `UID` instead of `ID`.
+- [x] Update relation FK fields to integer IDs where appropriate.
+- [x] Keep model-specific UID prefixes (`user`, `clnc`, `ptnt`, etc.).
 
 ### 2) Query/Service Layer
-- [ ] Switch external lookups from `id` to `uid`.
-- [ ] Keep internal joins and relation traversal on integer `id`.
-- [ ] Ensure enqueue/job payload semantics remain external-UID-safe.
+- [x] Switch external lookups from `id` to `uid`.
+- [x] Keep internal joins and relation traversal on integer `id`.
+- [x] Ensure enqueue/job payload semantics remain external-UID-safe.
 
 ### 3) Migrations/Schema
 - [ ] Rewrite bootstrap schema for integer PK + UID unique constraints.
@@ -32,12 +32,12 @@
 - [ ] Keep FTS setup and triggers compatible with new keys.
 
 ### 4) Tests/Seeders
-- [ ] Update tests expecting string IDs.
+- [x] Update tests expecting string IDs.
 - [ ] Update seeders/fixtures to use UID for external selection.
 - [ ] Re-run migrations and DB bootstrap tests.
 
 ### 5) Validation
-- [ ] Run `go test ./...`.
+- [x] Run `go test ./...`.
 - [ ] Run `make docker/image`.
 - [ ] Report files changed and remaining follow-ups.
 

--- a/docs/ai/sqlite_int_pk_uid_plan.md
+++ b/docs/ai/sqlite_int_pk_uid_plan.md
@@ -1,0 +1,46 @@
+# SQLite Integer PK + UID Plan
+
+## Goal
+- Move all core models and schema tables to `id INTEGER PRIMARY KEY`.
+- Keep prefixed public IDs as `uid TEXT NOT NULL UNIQUE`.
+- Use integer foreign keys internally for joins and indexes.
+- Keep external/API references stable by using `uid` in routes and request payloads.
+
+## Git/Branch Checklist
+- [x] Stash local unrelated change (`internal/services/dashboard/service.go`).
+- [x] Fetch and prune remotes.
+- [x] Create new branch from `origin/main`: `feat/sqlite-int-pk-uid`.
+- [ ] Optionally reconcile local `main` divergence after this feature ships.
+
+## Implementation Checklist
+
+### 1) Model Layer
+- [ ] Update model identity fields to `ID uint` + `UID string`.
+- [ ] Update `BeforeCreate` hooks to assign `UID` instead of `ID`.
+- [ ] Update relation FK fields to integer IDs where appropriate.
+- [ ] Keep model-specific UID prefixes (`user`, `clnc`, `ptnt`, etc.).
+
+### 2) Query/Service Layer
+- [ ] Switch external lookups from `id` to `uid`.
+- [ ] Keep internal joins and relation traversal on integer `id`.
+- [ ] Ensure enqueue/job payload semantics remain external-UID-safe.
+
+### 3) Migrations/Schema
+- [ ] Rewrite bootstrap schema for integer PK + UID unique constraints.
+- [ ] Keep final columns/indexes expected by current app behavior.
+- [ ] Ensure FK constraints point to integer PK columns.
+- [ ] Keep FTS setup and triggers compatible with new keys.
+
+### 4) Tests/Seeders
+- [ ] Update tests expecting string IDs.
+- [ ] Update seeders/fixtures to use UID for external selection.
+- [ ] Re-run migrations and DB bootstrap tests.
+
+### 5) Validation
+- [ ] Run `go test ./...`.
+- [ ] Run `make docker/image`.
+- [ ] Report files changed and remaining follow-ups.
+
+## Notes
+- This branch assumes no production data migration is required.
+- If data appears before merge, this plan must switch to additive/online migration.

--- a/goose/migrations/20240610233300_init.sql
+++ b/goose/migrations/20240610233300_init.sql
@@ -1,122 +1,195 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE IF NOT EXISTS `todos` (`created_at` datetime,`content` text NOT NULL DEFAULT null,`user_id` text NOT NULL DEFAULT null,`updated_at` datetime,`id` text NOT NULL DEFAULT null,`completed` numeric,PRIMARY KEY (`id`),CONSTRAINT `fk_users_todos` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`));
-CREATE INDEX `idx_todos_user_id` ON `todos`(`user_id`);
-CREATE INDEX `idx_todos_created_at` ON `todos`(`created_at` desc);
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY,
+  uid TEXT NOT NULL UNIQUE,
+  ext_id TEXT,
+  profile_pic TEXT,
+  name TEXT,
+  email TEXT NOT NULL UNIQUE,
+  password TEXT,
+  theme TEXT,
+  reset_token TEXT,
+  confirm_email_token TEXT,
+  confirm_email_expires_at DATETIME,
+  reset_token_expires_at DATETIME,
+  phone TEXT,
+  timezone TEXT,
+  role TEXT NOT NULL,
+  created_at DATETIME,
+  updated_at DATETIME
+);
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+CREATE INDEX IF NOT EXISTS idx_users_ext_id ON users(ext_id);
 
-CREATE TABLE IF NOT EXISTS "articles"  (`created_at` datetime,`updated_at` datetime,`user_id` text NOT NULL DEFAULT null,`title` text,`content` text,`id` text NOT NULL DEFAULT null,PRIMARY KEY (`id`),CONSTRAINT `fk_users_articles` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`),CONSTRAINT `fk_articles_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`));
-CREATE INDEX `idx_articles_created_at` ON `articles`(`created_at` desc);
-CREATE INDEX `idx_articles_user_id` ON `articles`(`user_id`);
+CREATE TABLE IF NOT EXISTS clinics (
+  id INTEGER PRIMARY KEY,
+  uid TEXT NOT NULL UNIQUE,
+  ext_id TEXT,
+  user_id INTEGER NOT NULL,
+  cover_pic TEXT,
+  profile_pic TEXT,
+  name TEXT NOT NULL,
+  email TEXT,
+  phone TEXT NOT NULL,
+  line1 TEXT,
+  line2 TEXT,
+  city TEXT,
+  state TEXT,
+  country TEXT,
+  zip TEXT,
+  whatsapp TEXT,
+  telegram TEXT,
+  messenger TEXT,
+  instagram TEXT,
+  facebook TEXT,
+  favorite NUMERIC,
+  price INTEGER,
+  deleted_at DATETIME,
+  created_at DATETIME,
+  updated_at DATETIME,
+  FOREIGN KEY(user_id) REFERENCES users(id)
+);
+CREATE INDEX IF NOT EXISTS idx_clinics_user_id ON clinics(user_id);
 
-CREATE TABLE IF NOT EXISTS "comments"  (`user_id` text NOT NULL DEFAULT null,`article_id` text NOT NULL DEFAULT null,`content` text,`created_at` datetime,`updated_at` datetime,`id` text NOT NULL DEFAULT null,PRIMARY KEY (`id`),CONSTRAINT `fk_users_comments` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`),CONSTRAINT `fk_articles_comments` FOREIGN KEY (`article_id`) REFERENCES `articles`(`id`),CONSTRAINT `fk_comments_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`));
-CREATE INDEX `idx_comments_user_id` ON `comments`(`user_id`);
-CREATE INDEX `idx_comments_article_id` ON `comments`(`article_id`);
+CREATE TABLE IF NOT EXISTS patients (
+  id INTEGER PRIMARY KEY,
+  uid TEXT NOT NULL UNIQUE,
+  ext_id TEXT,
+  user_id INTEGER NOT NULL,
+  email TEXT,
+  phone TEXT NOT NULL,
+  ocupation TEXT,
+  name TEXT NOT NULL,
+  profile_pic TEXT,
+  family_history TEXT,
+  medical_background TEXT,
+  notes TEXT,
+  line1 TEXT,
+  line2 TEXT,
+  city TEXT,
+  state TEXT,
+  country TEXT,
+  zip TEXT,
+  whatsapp TEXT,
+  telegram TEXT,
+  messenger TEXT,
+  instagram TEXT,
+  facebook TEXT,
+  age INTEGER,
+  enable_notifications NUMERIC,
+  via_email NUMERIC,
+  via_whatsapp NUMERIC,
+  via_messenger NUMERIC,
+  via_telegram NUMERIC,
+  deleted_at DATETIME,
+  created_at DATETIME,
+  updated_at DATETIME,
+  FOREIGN KEY(user_id) REFERENCES users(id)
+);
+CREATE INDEX IF NOT EXISTS idx_patients_user_id ON patients(user_id);
 
-CREATE TABLE IF NOT EXISTS "clinics"  (
-  `ext_id` text,
-  `name` text NOT NULL DEFAULT null,
-  `line1` text,
-  `line2` text,
-  `city` text,
-  `state` text,
-  `country` text,
-  `zip` text,
-  `email` text,
-  `phone` text NOT NULL DEFAULT null,
-  `instagram_url` text,
-  `facebook_url` text,
-  `user_id` text NOT NULL DEFAULT null,
-  `created_at` datetime,
-  `updated_at` datetime,
-  `id` text NOT NULL DEFAULT null,
-  `whatsapp` text,
-  `telegram` text,
-  `instagram` text,
-  `facebook` text,
-  `messenger` text,
-  `profile_pic` text,
-  `cover_pic` text,
-  `deleted_at` datetime,
-  `favorite` numeric,
-  PRIMARY KEY (`id`),
-  CONSTRAINT `fk_clinics_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`),
-  CONSTRAINT `fk_users_clinics` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`));
-CREATE INDEX `idx_clinics_user_id` ON `clinics`(`user_id`);
-CREATE INDEX `idx_clinics_deleted_at` ON `clinics`(`deleted_at`);
+CREATE TABLE IF NOT EXISTS appointments (
+  id INTEGER PRIMARY KEY,
+  uid TEXT NOT NULL UNIQUE,
+  ext_id TEXT,
+  token TEXT,
+  summary TEXT,
+  observations TEXT,
+  conclusions TEXT,
+  notes TEXT,
+  hashtags TEXT,
+  timezone TEXT,
+  user_id INTEGER NOT NULL,
+  clinic_id INTEGER NOT NULL,
+  patient_id INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  duration INTEGER,
+  price INTEGER,
+  booked_year INTEGER,
+  booked_month INTEGER,
+  booked_day INTEGER,
+  booked_hour INTEGER,
+  booked_minute INTEGER,
+  no_show NUMERIC,
+  enable_notifications NUMERIC,
+  via_email NUMERIC,
+  via_whatsapp NUMERIC,
+  via_messenger NUMERIC,
+  via_telegram NUMERIC,
+  booked_at DATETIME NOT NULL,
+  old_booked_at DATETIME,
+  booked_alert_sent_at DATETIME,
+  reminder_alert_sent_at DATETIME,
+  viewed_at DATETIME,
+  confirmed_at DATETIME,
+  done_at DATETIME,
+  canceled_at DATETIME,
+  pending_at DATETIME,
+  rescheduled_at DATETIME,
+  deleted_at DATETIME,
+  created_at DATETIME,
+  updated_at DATETIME,
+  FOREIGN KEY(user_id) REFERENCES users(id),
+  FOREIGN KEY(clinic_id) REFERENCES clinics(id),
+  FOREIGN KEY(patient_id) REFERENCES patients(id)
+);
+CREATE INDEX IF NOT EXISTS idx_appointments_user_id ON appointments(user_id);
+CREATE INDEX IF NOT EXISTS idx_appointments_status ON appointments(status);
+CREATE INDEX IF NOT EXISTS idx_appointments_clinic_id ON appointments(clinic_id);
+CREATE INDEX IF NOT EXISTS idx_appointments_patient_id ON appointments(patient_id);
+CREATE INDEX IF NOT EXISTS idx_appointments_booked_at ON appointments(booked_at);
+CREATE INDEX IF NOT EXISTS idx_appointments_old_booked_at ON appointments(old_booked_at);
 
-CREATE TABLE IF NOT EXISTS "patients"  (
-  `ext_id` text,
-  `email` text,
-  `phone` text NOT NULL DEFAULT null,
-  `facebook_url` text,
-  `profile_url` text,
-  `user_id` text NOT NULL DEFAULT null,
-  `created_at` datetime,`updated_at` datetime,
-  `id` text NOT NULL DEFAULT null,
-  `line1` text,`line2` text,
-  `city` text,`state` text,
-  `country` text,`zip` text,
-  `first_name` text NOT NULL DEFAULT null,
-  `last_name` text NOT NULL DEFAULT null,
-  `age` integer,
-  `profile_pic` text,
-  `facebook` text,
-  `whatsapp` text,
-  `telegram` text,
-  `messenger` text,
-  `instagram` text,
-  `username` text,
-  `pass` text,
-  `ocupation` text,
-  `enable_notifications` numeric,
-  `family_history` text,
-  `medical_background` text,
-  `notes` text,
-  `via_email` numeric,
-  `via_whatsapp` numeric,
-  `via_messenger` numeric,
-  `via_telegram` numeric,
-  `deleted_at` datetime,
-  PRIMARY KEY (`id`),
-  CONSTRAINT `fk_patients_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`),
-  CONSTRAINT `fk_users_patients` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`));
-CREATE INDEX `idx_patients_user_id` ON `patients`(`user_id`);
-CREATE INDEX `idx_patients_deleted_at` ON `patients`(`deleted_at`);
+CREATE TABLE IF NOT EXISTS alerts (
+  id INTEGER PRIMARY KEY,
+  uid TEXT NOT NULL UNIQUE,
+  medium TEXT NOT NULL,
+  name TEXT NOT NULL,
+  title TEXT,
+  sub TEXT,
+  message TEXT,
+  "from" TEXT,
+  "to" TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  alertable_id TEXT,
+  alertable_type TEXT,
+  created_at DATETIME,
+  updated_at DATETIME
+);
+CREATE INDEX IF NOT EXISTS poly_fevnt_idx ON alerts(alertable_id, alertable_type);
+CREATE INDEX IF NOT EXISTS idx_alerts_status ON alerts(status);
+CREATE INDEX IF NOT EXISTS idx_alerts_name ON alerts(name);
+CREATE INDEX IF NOT EXISTS idx_alerts_medium ON alerts(medium);
 
-CREATE TABLE IF NOT EXISTS "appointments"  (`booked_at` datetime NOT NULL DEFAULT null,`confirmed_at` datetime DEFAULT null,`canceled_at` datetime DEFAULT null,`rescheduled_at` datetime DEFAULT null,`accepted_at` datetime DEFAULT null,`no_show_at` datetime DEFAULT null,`deleted_at` datetime,`created_at` datetime,`updated_at` datetime,`id` text NOT NULL DEFAULT null,`summary` text,`observations` text,`conclusions` text,`notes` text,`ext_id` text,`hashtags` text,`user_id` text NOT NULL DEFAULT null,`clinic_id` text NOT NULL DEFAULT null,`patient_id` text NOT NULL DEFAULT null,`duration` integer,`booked_month` integer,`booked_minute` integer,`booked_hour` integer,`booked_day` integer,`booked_year` integer,`confirmed` numeric,`canceled` numeric,`rescheduled` numeric,`accepted` numeric,`no_show` numeric,`cost` integer,`viewed_at` datetime DEFAULT null,`sent_at` datetime DEFAULT null,`started_at` datetime DEFAULT null,`done_at` datetime DEFAULT null,`begin_at` datetime DEFAULT null,`status` text NOT NULL DEFAULT "draft", `notification_status` text NOT NULL DEFAULT "pending", `enable_notifications` numeric, `via_email` numeric, `via_whatsapp` numeric, `via_messenger` numeric, `via_telegram` numeric, `booked_alert_sent_at` datetime DEFAULT null, `reminder_alert_sent_at` datetime DEFAULT null, `pending_at` datetime DEFAULT null, `old_booked_at` datetime DEFAULT null, `token` text,PRIMARY KEY (`id`),CONSTRAINT `fk_appointments_clinic` FOREIGN KEY (`clinic_id`) REFERENCES `clinics`(`id`),CONSTRAINT `fk_appointments_patient` FOREIGN KEY (`patient_id`) REFERENCES `patients`(`id`),CONSTRAINT `fk_users_appointments` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`),CONSTRAINT `fk_patients_appoinments` FOREIGN KEY (`patient_id`) REFERENCES `patients`(`id`),CONSTRAINT `fk_patients_appointments` FOREIGN KEY (`patient_id`) REFERENCES `patients`(`id`));
-CREATE INDEX `idx_appointments_user_id` ON `appointments`(`user_id`);
-CREATE INDEX `idx_appointments_status` ON `appointments`(`status`);
-CREATE INDEX `idx_appointments_clinic_id` ON `appointments`(`clinic_id`);
-CREATE INDEX `idx_appointments_patient_id` ON `appointments`(`patient_id`);
-CREATE INDEX `idx_appointments_deleted_at` ON `appointments`(`deleted_at`);
-CREATE INDEX `idx_appointments_notification_status` ON `appointments`(`notification_status`);
-
-CREATE VIRTUAL TABLE global_fts USING fts5(gid, primary, secondary, tertiary)
-/* global_fts(gid,"primary",secondary,tertiary) */;
-CREATE TABLE IF NOT EXISTS 'global_fts_data'(id INTEGER PRIMARY KEY, block BLOB);
-CREATE TABLE IF NOT EXISTS 'global_fts_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID;
-CREATE TABLE IF NOT EXISTS 'global_fts_content'(id INTEGER PRIMARY KEY, c0, c1, c2, c3);
-CREATE TABLE IF NOT EXISTS 'global_fts_docsize'(id INTEGER PRIMARY KEY, sz BLOB);
-CREATE TABLE IF NOT EXISTS 'global_fts_config'(k PRIMARY KEY, v) WITHOUT ROWID;
-
-CREATE TABLE `alerts` (`medium` text NOT NULL DEFAULT null,`name` text NOT NULL DEFAULT null,`title` text,`sub` text,`message` text,`sent_at` datetime DEFAULT null,`delivered_at` datetime DEFAULT null,`viewed_at` datetime DEFAULT null,`from` text,`to` text,`status` text NOT NULL DEFAULT "pending",`alertable_id` text,`alertable_type` text,`created_at` datetime,`updated_at` datetime,`id` text NOT NULL DEFAULT null,PRIMARY KEY (`id`));
-CREATE INDEX `poly_fevnt_idx` ON `alerts`(`alertable_id`,`alertable_type`);
-CREATE INDEX `idx_alerts_status` ON `alerts`(`status`);
-CREATE INDEX `idx_alerts_name` ON `alerts`(`name`);
-CREATE INDEX `idx_alerts_medium` ON `alerts`(`medium`);
-
-CREATE TABLE IF NOT EXISTS "feed_events"  (`subject` text,`subject_id` text NOT NULL DEFAULT null,`subject_type` text NOT NULL DEFAULT null,`subject_url` text,`action` text,`target` text NOT NULL DEFAULT null,`target_id` text NOT NULL DEFAULT null,`target_type` text,`target_url` text,`ocurred_at` datetime DEFAULT null,`extra1` text,`extra2` text,`extra3` text,`feed_eventable_id` text,`feed_eventable_type` text,`created_at` datetime,`updated_at` datetime,`id` text NOT NULL DEFAULT null,`name` text NOT NULL DEFAULT null,PRIMARY KEY (`id`));
-CREATE INDEX `fe_target_idx` ON `feed_events`(`target`,`target_id`);
-CREATE INDEX `idx_feed_events_ocurred_at` ON `feed_events`(`ocurred_at`);
-CREATE INDEX `fe_poly_idx` ON `feed_events`(`feed_eventable_id`,`feed_eventable_type`);
-CREATE INDEX `idx_feed_events_name` ON `feed_events`(`name`);
-CREATE INDEX `fe_subject_idx` ON `feed_events`(`subject_id`,`subject_type`);
-CREATE INDEX `idx_feed_events_action` ON `feed_events`(`action`);
-CREATE INDEX `idx_appointments_old_booked_at` ON `appointments`(`old_booked_at`);
-
-CREATE TABLE IF NOT EXISTS "users"  (`confirm_email_expires_at` datetime,`reset_token_expires_at` datetime,`name` text,`email` text NOT NULL DEFAULT null,`role` text NOT NULL DEFAULT null,`password` text,`theme` text,`reset_token` text,`confirm_email_token` text,`created_at` datetime,`updated_at` datetime,`id` text NOT NULL DEFAULT null,`ext_id` text,`profile_pic` text,PRIMARY KEY (`id`));
-CREATE UNIQUE INDEX `idx_users_email` ON `users`(`email`);
-CREATE INDEX `idx_users_role` ON `users`(`role`);
+CREATE TABLE IF NOT EXISTS feed_events (
+  id INTEGER PRIMARY KEY,
+  uid TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  subject TEXT,
+  subject_id TEXT NOT NULL,
+  subject_type TEXT NOT NULL,
+  subject_url TEXT,
+  action TEXT,
+  target TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  target_type TEXT,
+  target_url TEXT,
+  ocurred_at DATETIME,
+  extra1 TEXT,
+  extra2 TEXT,
+  extra3 TEXT,
+  feed_eventable_id TEXT,
+  feed_eventable_type TEXT,
+  created_at DATETIME,
+  updated_at DATETIME
+);
+CREATE INDEX IF NOT EXISTS fe_target_idx ON feed_events(target, target_id);
+CREATE INDEX IF NOT EXISTS idx_feed_events_ocurred_at ON feed_events(ocurred_at);
+CREATE INDEX IF NOT EXISTS fe_poly_idx ON feed_events(feed_eventable_id, feed_eventable_type);
+CREATE INDEX IF NOT EXISTS idx_feed_events_name ON feed_events(name);
+CREATE INDEX IF NOT EXISTS fe_subject_idx ON feed_events(subject_id, subject_type);
+CREATE INDEX IF NOT EXISTS idx_feed_events_action ON feed_events(action);
 -- +goose StatementEnd
 
 -- +goose Down

--- a/goose/migrations/20240610233323_patient_fts.sql
+++ b/goose/migrations/20240610233323_patient_fts.sql
@@ -3,8 +3,8 @@
 INSERT INTO global_fts (gid, "primary", "secondary", "tertiary")
 SELECT
     id,
-    email || ' ' || phone as "primary",
-    first_name || ' ' || last_name as "secondary",
+    name as "primary",
+    email || ' ' || phone as "secondary",
     ocupation || ' ' || age || ' ' || family_history || ' ' || medical_background || ' ' || notes as "tertiary"
 FROM
     patients;
@@ -15,8 +15,8 @@ BEGIN
   INSERT INTO global_fts (gid, "primary", "secondary", "tertiary")
   VALUES (
       new.id,
+      new.name,
       new.email || ' ' || new.phone,
-      new.first_name || ' ' || new.last_name,
       new.ocupation || '\n' || new.age || '\n' || new.family_history || '\n' || new.medical_background || '\n' || new.notes
   );
 END;
@@ -26,8 +26,8 @@ CREATE TRIGGER IF NOT EXISTS trgr_update_patients_on_gfts
 BEGIN
   UPDATE global_fts
   SET
-      "primary" = new.email || ' ' || new.phone,
-      "secondary" = new.first_name || ' ' || new.last_name,
+      "primary" = new.name,
+      "secondary" = new.email || ' ' || new.phone,
       "tertiary" = new.ocupation || '\n' || new.age || '\n' || new.family_history || '\n' || new.medical_background || '\n' || new.notes
   WHERE gid = NEW.id;
 END;
@@ -48,5 +48,4 @@ DROP TRIGGER IF EXISTS trgr_update_patients_on_gfts;
 
 DROP TRIGGER IF EXISTS trgr_delete_patients_on_gfts;
 -- +goose StatementEnd
-
 

--- a/goose/migrations/20240616184634_add_price_col_to_appnt_and_clinic.sql
+++ b/goose/migrations/20240616184634_add_price_col_to_appnt_and_clinic.sql
@@ -1,16 +1,10 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE appointments ADD COLUMN price integer;
-UPDATE appointments
-SET price = (
-    SELECT cost
-    FROM appointments a2
-);
-ALTER TABLE appointments DROP COLUMN cost;
+SELECT 'price is part of baseline schema';
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-SELECT 'theres no down for this operation';
+SELECT 'no down';
 -- +goose StatementEnd
 --

--- a/goose/migrations/20240617182649_add_price_to_clinic.sql
+++ b/goose/migrations/20240617182649_add_price_to_clinic.sql
@@ -1,10 +1,10 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE clinics ADD COLUMN price integer;
+SELECT 'price is part of baseline schema';
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-ALTER TABLE clinics DROP COLUMN price;
+SELECT 'no down';
 -- +goose StatementEnd
 -

--- a/goose/migrations/20240621215250_add_phone_to_users.sql
+++ b/goose/migrations/20240621215250_add_phone_to_users.sql
@@ -1,11 +1,9 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE users ADD COLUMN phone string;
 CREATE INDEX IF NOT EXISTS `idx_users_ext_id` ON `users`(`ext_id`);
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-ALTER TABLE users DROP COLUMN phone;
-DROP INDEX IF EXISTS `idx_users_ext_id` ON `users`(`ext_id`);
+SELECT 'no down';
 -- +goose StatementEnd

--- a/goose/migrations/20240627231150_add_name_to_patients.sql
+++ b/goose/migrations/20240627231150_add_name_to_patients.sql
@@ -1,22 +1,19 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE patients ADD COLUMN name TEXT;
-
--- Never Update from migrations, if you have enough data since it
--- runs in a transaction it will lock everything.
--- Create a bettes Expand/Collapse strategy to make it incrementally.
---
--- UPDATE patients
--- SET name = (
---     SELECT first_name || ' ' || last_name
---     FROM patients p2
--- );
-
 DROP TRIGGER IF EXISTS trgr_insert_patients_on_gfts;
 DROP TRIGGER IF EXISTS trgr_update_patients_on_gfts;
+DROP TRIGGER IF EXISTS trgr_delete_patients_on_gfts;
 
-ALTER TABLE patients DROP COLUMN first_name;
-ALTER TABLE patients DROP COLUMN last_name;
+DELETE FROM global_fts WHERE gid IN (SELECT id FROM patients);
+
+INSERT INTO global_fts (gid, "primary", "secondary", "tertiary")
+SELECT
+    id,
+    name,
+    email || ' ' || phone,
+    ocupation || '\n' || family_history || '\n' || medical_background || '\n' || notes
+FROM
+    patients;
 
 CREATE TRIGGER IF NOT EXISTS trgr_insert_patients_on_gfts
   AFTER INSERT on patients
@@ -39,6 +36,13 @@ BEGIN
       "secondary" = new.email || ' ' || new.phone,
       "tertiary" = new.ocupation || '\n' || new.family_history || '\n' || new.medical_background || '\n' || new.notes
   WHERE gid = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trgr_delete_patients_on_gfts
+  AFTER DELETE on patients
+BEGIN
+  DELETE FROM global_fts
+  WHERE gid = OLD.id;
 END;
 
 -- +goose StatementEnd

--- a/goose/migrations/20240705164703_add_timezone_to_appointments.sql
+++ b/goose/migrations/20240705164703_add_timezone_to_appointments.sql
@@ -1,9 +1,9 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE appointments ADD COLUMN timezone text;
+SELECT 'timezone is part of baseline schema';
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-ALTER TABLE appointments DROP COLUMN timezone;
+SELECT 'no down';
 -- +goose StatementEnd

--- a/goose/migrations/20240705164845_add_timezone_and_localelang_to_users.sql
+++ b/goose/migrations/20240705164845_add_timezone_and_localelang_to_users.sql
@@ -1,9 +1,9 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE users ADD COLUMN timezone text;
+SELECT 'timezone is part of baseline schema';
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-ALTER TABLE users DROP COLUMN timezone;
+SELECT 'no down';
 -- +goose StatementEnd

--- a/internal/database/seeder/seeder_test.go
+++ b/internal/database/seeder/seeder_test.go
@@ -117,7 +117,7 @@ func TestCreateBulkAppointmentsGuards(t *testing.T) {
 		t.Fatalf("expected no appointments when clinics/patients missing, got %d", created)
 	}
 
-	created, err = createBulkAppointments(t.Context(), db, owner, nil, 1, []models.Clinic{{ID: "cln"}}, []models.Patient{{ID: "pat"}}, 0)
+	created, err = createBulkAppointments(t.Context(), db, owner, nil, 1, []models.Clinic{{ID: 1, UID: "cln"}}, []models.Patient{{ID: 1, UID: "pat"}}, 0)
 	if err != nil {
 		t.Fatalf("expected count guard return without error: %v", err)
 	}

--- a/internal/mailer/appointmentmailer.go
+++ b/internal/mailer/appointmentmailer.go
@@ -13,7 +13,7 @@ import (
 )
 
 func SendAppointmentBookedEmail(env *appenv.Env, appointment models.Appointment) error {
-	if appointment.Patient.ID == "" || appointment.Clinic.ID == "" {
+	if appointment.Patient.ID == 0 || appointment.Clinic.ID == 0 {
 		fmt.Println(errors.New("appointment Clinic or Patient association is missing, they must be Preloaded"))
 	}
 
@@ -41,7 +41,7 @@ func SendAppointmentBookedEmail(env *appenv.Env, appointment models.Appointment)
 }
 
 func SendAppointmentReminderEmail(env *appenv.Env, appointment models.Appointment) error {
-	if appointment.Patient.ID == "" || appointment.Clinic.ID == "" {
+	if appointment.Patient.ID == 0 || appointment.Clinic.ID == 0 {
 		return errors.New("appointment Clinic or Patient association is missing, they must be Preloaded")
 	}
 

--- a/internal/middleware/authentication.go
+++ b/internal/middleware/authentication.go
@@ -27,7 +27,7 @@ func MustAuthenticate(authRuntime auth.Runtime) func(c fiber.Ctx) error {
 
 		// Bind resolved identity to request locals for downstream handlers/views.
 		c.Locals("current_user", cu)
-		c.Locals("uid", cu.ID)
+		c.Locals("uid", cu.UID)
 		return c.Next()
 	}
 }
@@ -63,7 +63,7 @@ func MustBeAdmin(authRuntime auth.Runtime) func(c fiber.Ctx) error {
 
 		// Bind resolved identity to request locals for downstream handlers/views.
 		c.Locals("current_user", cu)
-		c.Locals("uid", cu.ID)
+		c.Locals("uid", cu.UID)
 
 		return c.Next()
 	}
@@ -75,7 +75,7 @@ func MaybeAuthenticate(authRuntime auth.Runtime) func(c fiber.Ctx) error {
 
 		// Bind resolved identity to request locals for downstream handlers/views.
 		c.Locals("current_user", cu)
-		c.Locals("uid", cu.ID)
+		c.Locals("uid", cu.UID)
 
 		return c.Next()
 	}

--- a/internal/middleware/authentication.go
+++ b/internal/middleware/authentication.go
@@ -12,6 +12,9 @@ import (
 func MustAuthenticate(authRuntime auth.Runtime) func(c fiber.Ctx) error {
 	return func(c fiber.Ctx) error {
 		cu, err := auth.Authenticate(c, authRuntime)
+		if err == nil && cu.ID == 0 {
+			err = fiber.ErrUnauthorized
+		}
 		if err != nil {
 			switch c.Accepts("text/html", "text/plain", "application/json") {
 			case "text/plain", "application/json":
@@ -35,6 +38,9 @@ func MustAuthenticate(authRuntime auth.Runtime) func(c fiber.Ctx) error {
 func MustBeAdmin(authRuntime auth.Runtime) func(c fiber.Ctx) error {
 	return func(c fiber.Ctx) error {
 		cu, err := auth.Authenticate(c, authRuntime)
+		if err == nil && cu.ID == 0 {
+			err = fiber.ErrUnauthorized
+		}
 		if err != nil {
 			switch c.Accepts("text/html", "text/plain", "application/json") {
 			case "text/html":

--- a/internal/middleware/authentication_test.go
+++ b/internal/middleware/authentication_test.go
@@ -106,8 +106,8 @@ func TestMustAuthenticate(t *testing.T) {
 	t.Run("authenticated request reaches handler with uid", func(t *testing.T) {
 		app := fiber.New()
 		app.Get("/protected", MustAuthenticate(rt), func(c fiber.Ctx) error {
-			if got := c.Locals("uid"); got != regular.ID {
-				t.Fatalf("expected uid local %q, got %#v", regular.ID, got)
+			if got := c.Locals("uid"); got != regular.UID {
+				t.Fatalf("expected uid local %q, got %#v", regular.UID, got)
 			}
 			return c.SendStatus(http.StatusNoContent)
 		})
@@ -197,8 +197,8 @@ func TestMustBeAdmin(t *testing.T) {
 	t.Run("admin request reaches handler", func(t *testing.T) {
 		app := fiber.New()
 		app.Get("/admin", MustBeAdmin(rt), func(c fiber.Ctx) error {
-			if got := c.Locals("uid"); got != admin.ID {
-				t.Fatalf("expected uid local %q, got %#v", admin.ID, got)
+			if got := c.Locals("uid"); got != admin.UID {
+				t.Fatalf("expected uid local %q, got %#v", admin.UID, got)
 			}
 			return c.SendStatus(http.StatusNoContent)
 		})
@@ -214,7 +214,7 @@ func TestMustBeAdmin(t *testing.T) {
 		}
 	})
 
-	if regular.ID == "" {
+	if regular.UID == "" {
 		t.Fatalf("guard to keep regular user referenced")
 	}
 }
@@ -244,8 +244,8 @@ func TestMaybeAuthenticate(t *testing.T) {
 	t.Run("with valid token sets user locals", func(t *testing.T) {
 		app := fiber.New()
 		app.Get("/maybe", MaybeAuthenticate(rt), func(c fiber.Ctx) error {
-			if got := c.Locals("uid"); got != user.ID {
-				t.Fatalf("expected uid local %q, got %#v", user.ID, got)
+			if got := c.Locals("uid"); got != user.UID {
+				t.Fatalf("expected uid local %q, got %#v", user.UID, got)
 			}
 			return c.SendStatus(http.StatusNoContent)
 		})
@@ -274,12 +274,12 @@ func newMiddlewareAuthRuntime(t *testing.T) (testAuthRuntime, models.User, strin
 	}
 
 	rt := testAuthRuntime{env: &appenv.Env{JWTSecret: "01234567890123456789012345678901"}, db: db}
-	user := models.User{ID: "usr_regular", Email: "regular@example.com", Role: models.UserRoleUser}
+	user := models.User{UID: "usr_regular", Email: "regular@example.com", Role: models.UserRoleUser}
 	if err := db.Create(&user).Error; err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
-	token, err := auth.JWTCreateToken(rt.env, user.Email, user.ID)
+	token, err := auth.JWTCreateToken(rt.env, user.Email, user.UID)
 	if err != nil {
 		t.Fatalf("create token: %v", err)
 	}
@@ -290,11 +290,11 @@ func newMiddlewareAuthRuntime(t *testing.T) (testAuthRuntime, models.User, strin
 func newMiddlewareAdminRuntime(t *testing.T) (testAuthRuntime, models.User, string, models.User, string) {
 	t.Helper()
 	rt, regular, regularToken := newMiddlewareAuthRuntime(t)
-	admin := models.User{ID: "usr_admin", Email: "admin@example.com", Role: models.UserRoleAdmin}
+	admin := models.User{UID: "usr_admin", Email: "admin@example.com", Role: models.UserRoleAdmin}
 	if err := rt.db.Create(&admin).Error; err != nil {
 		t.Fatalf("create admin user: %v", err)
 	}
-	adminToken, err := auth.JWTCreateToken(rt.env, admin.Email, admin.ID)
+	adminToken, err := auth.JWTCreateToken(rt.env, admin.Email, admin.UID)
 	if err != nil {
 		t.Fatalf("create admin token: %v", err)
 	}

--- a/internal/models/alert.go
+++ b/internal/models/alert.go
@@ -28,6 +28,8 @@ const (
 )
 
 type Alert struct {
+	ID            uint        `gorm:"primaryKey" form:"-"`
+	UID           string      `gorm:"uniqueIndex;default:null;not null" form:"-"`
 	Medium        AlertMedium `gorm:"index;default:null;not null;type:string" form:"-"`
 	Name          string      `gorm:"index;default:null;not null"`
 	Title         string
@@ -42,6 +44,6 @@ type Alert struct {
 }
 
 func (a *Alert) BeforeCreate(tx *gorm.DB) (err error) {
-	a.ID = xid.New("alrt")
+	a.UID = xid.New("alrt")
 	return nil
 }

--- a/internal/models/appointment.go
+++ b/internal/models/appointment.go
@@ -51,7 +51,8 @@ type Appointment struct {
 	RescheduledAt       time.Time `gorm:"default:null"`
 	DeletedAt           gorm.DeletedAt
 	ModelBase
-	ID           string            `gorm:"primarykey;default:null;not null" form:"_"`
+	ID           uint              `gorm:"primaryKey" form:"_"`
+	UID          string            `gorm:"uniqueIndex;default:null;not null" form:"_"`
 	ExtID        string            `form:"extId"`
 	Token        string            `form:"_"`
 	Summary      string            `form:"summary"`
@@ -60,9 +61,9 @@ type Appointment struct {
 	Notes        string            `form:"notes"`
 	Hashtags     string            `form:"hashtags"`
 	Timezone     string            `form:"timezone"`
-	UserID       string            `gorm:"index;default:null;not null"`
-	ClinicID     string            `gorm:"index;default:null;not null" form:"clinicId"`
-	PatientID    string            `gorm:"index;default:null;not null" form:"patientId"`
+	UserID       uint              `gorm:"index;default:null;not null"`
+	ClinicID     uint              `gorm:"index;default:null;not null" form:"clinicId"`
+	PatientID    uint              `gorm:"index;default:null;not null" form:"patientId"`
 	Status       AppointmentStatus `gorm:"index;default:pending;not null;type:string" form:"status"`
 	FeedEvents   []FeedEvent       `gorm:"polymorphic:FeedEventable;"`
 	Alerts       []Alert           `gorm:"polymorphic:Alertable;"`
@@ -81,7 +82,7 @@ type Appointment struct {
 }
 
 func (a *Appointment) BeforeCreate(tx *gorm.DB) error {
-	a.ID = xid.New("apnt")
+	a.UID = xid.New("apnt")
 	if a.Status == "" {
 		a.Status = ApntStatusPending
 	}
@@ -109,15 +110,15 @@ func (a *Appointment) PriceInputValue() string {
 }
 
 func (a *Appointment) ConfirmPath() string {
-	return "/appointments/" + a.ID + "/patient/confirm/" + a.Token
+	return "/appointments/" + a.UID + "/patient/confirm/" + a.Token
 }
 
 func (a *Appointment) CancelPath() string {
-	return "/appointments/" + a.ID + "/patient/cancel/" + a.Token
+	return "/appointments/" + a.UID + "/patient/cancel/" + a.Token
 }
 
 func (a *Appointment) RescheduledPath() string {
-	return "/appointments/" + a.ID + "/patient/reschedule/" + a.Token
+	return "/appointments/" + a.UID + "/patient/reschedule/" + a.Token
 }
 
 // Scopes

--- a/internal/models/base.go
+++ b/internal/models/base.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"miconsul/internal/lib/xid"
 	"time"
 
 	"gorm.io/gorm"
@@ -11,7 +10,6 @@ type ModelBase struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	fieldErrors map[string]string `gorm:"-:all"`
-	ID          string            `gorm:"primarykey;default:null;not null" form:"__blank"`
 }
 
 type Address struct {
@@ -41,11 +39,6 @@ type NotificationFlags struct {
 	ViaWhatsapp         bool `form:"viaWhatsapp"`
 	ViaMessenger        bool `form:"viaMessenger"`
 	ViaTelegram         bool `form:"viaTelegram"`
-}
-
-func (mb *ModelBase) BeforeCreate(tx *gorm.DB) error {
-	mb.ID = xid.New("____")
-	return nil
 }
 
 func (mb *ModelBase) IsValid() error {

--- a/internal/models/clinic.go
+++ b/internal/models/clinic.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Clinic struct {
-	ID         string `gorm:"primarykey;default:null;not null" form:"_"`
+	ID         uint   `gorm:"primaryKey" form:"_"`
+	UID        string `gorm:"uniqueIndex;default:null;not null" form:"_"`
 	ExtID      string `gorm:"index;default:null;" form:"_"`
-	UserID     string `gorm:"index;default:null;not null"`
+	UserID     uint   `gorm:"index;default:null;not null"`
 	CoverPic   string
 	ProfilePic string         `form:"profilePic"`
 	Name       string         `gorm:"default:null;not null" form:"name"`
@@ -36,7 +37,7 @@ func (c *Clinic) BeforeCreate(tx *gorm.DB) error {
 		return errors.New("invalid data found in clinic record")
 	}
 
-	c.ID = xid.New("clnc")
+	c.UID = xid.New("clnc")
 	return nil
 }
 

--- a/internal/models/feed_event.go
+++ b/internal/models/feed_event.go
@@ -23,6 +23,8 @@ const (
 )
 
 type FeedEvent struct {
+	ID                uint   `gorm:"primaryKey"`
+	UID               string `gorm:"uniqueIndex;default:null;not null"`
 	extID             string `gorm:"index;default:null;not null"`
 	Name              string `gorm:"index;default:null;not null"`
 	Subject           string
@@ -47,6 +49,6 @@ type FeedEvent struct {
 }
 
 func (fe *FeedEvent) BeforeCreate(tx *gorm.DB) (err error) {
-	fe.ID = xid.New("fevn")
+	fe.UID = xid.New("fevn")
 	return nil
 }

--- a/internal/models/logbook.go
+++ b/internal/models/logbook.go
@@ -17,6 +17,8 @@ const (
 )
 
 type Logbook struct {
+	ID              uint   `gorm:"primaryKey"`
+	UID             string `gorm:"uniqueIndex;default:null;not null"`
 	Log             string `gorm:"default:null;not null"`
 	Msg             string
 	Data            string
@@ -27,6 +29,6 @@ type Logbook struct {
 }
 
 func (l *Logbook) BeforeCreate(tx *gorm.DB) (err error) {
-	l.ID = xid.New("lgbk")
+	l.UID = xid.New("lgbk")
 	return nil
 }

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -11,36 +11,36 @@ import (
 
 func TestEntityBeforeCreateHooksSetIDs(t *testing.T) {
 	alert := &Alert{}
-	if err := alert.BeforeCreate(nil); err != nil || !strings.HasPrefix(alert.ID, "alrt") {
-		t.Fatalf("alert before create failed: id=%q err=%v", alert.ID, err)
+	if err := alert.BeforeCreate(nil); err != nil || !strings.HasPrefix(alert.UID, "alrt") {
+		t.Fatalf("alert before create failed: uid=%q err=%v", alert.UID, err)
 	}
 
 	fe := &FeedEvent{}
-	if err := fe.BeforeCreate(nil); err != nil || !strings.HasPrefix(fe.ID, "fevn") {
-		t.Fatalf("feed event before create failed: id=%q err=%v", fe.ID, err)
+	if err := fe.BeforeCreate(nil); err != nil || !strings.HasPrefix(fe.UID, "fevn") {
+		t.Fatalf("feed event before create failed: uid=%q err=%v", fe.UID, err)
 	}
 
 	logbook := &Logbook{}
-	if err := logbook.BeforeCreate(nil); err != nil || !strings.HasPrefix(logbook.ID, "lgbk") {
-		t.Fatalf("logbook before create failed: id=%q err=%v", logbook.ID, err)
+	if err := logbook.BeforeCreate(nil); err != nil || !strings.HasPrefix(logbook.UID, "lgbk") {
+		t.Fatalf("logbook before create failed: uid=%q err=%v", logbook.UID, err)
 	}
 
 	session := &Session{}
-	if err := session.BeforeCreate(nil); err != nil || !strings.HasPrefix(session.ID, "sess") {
-		t.Fatalf("session before create failed: id=%q err=%v", session.ID, err)
+	if err := session.BeforeCreate(nil); err != nil || !strings.HasPrefix(session.UID, "sess") {
+		t.Fatalf("session before create failed: uid=%q err=%v", session.UID, err)
 	}
 
 	user := &User{}
-	if err := user.BeforeCreate(nil); err != nil || !strings.HasPrefix(user.ID, "user") {
-		t.Fatalf("user before create failed: id=%q err=%v", user.ID, err)
+	if err := user.BeforeCreate(nil); err != nil || !strings.HasPrefix(user.UID, "user") {
+		t.Fatalf("user before create failed: uid=%q err=%v", user.UID, err)
 	}
 
 	apnt := &Appointment{}
 	if err := apnt.BeforeCreate(nil); err != nil {
 		t.Fatalf("appointment before create error: %v", err)
 	}
-	if !strings.HasPrefix(apnt.ID, "apnt") {
-		t.Fatalf("unexpected appointment id %q", apnt.ID)
+	if !strings.HasPrefix(apnt.UID, "apnt") {
+		t.Fatalf("unexpected appointment uid %q", apnt.UID)
 	}
 	if apnt.Status != ApntStatusPending {
 		t.Fatalf("expected default pending status, got %q", apnt.Status)
@@ -68,7 +68,7 @@ func TestAppointmentBeforeSaveAndHelpers(t *testing.T) {
 		t.Fatalf("unexpected price input value %q", got)
 	}
 
-	apnt.ID = "apnt_1"
+	apnt.UID = "apnt_1"
 	apnt.Token = "tok_1"
 	if got := apnt.ConfirmPath(); got != "/appointments/apnt_1/patient/confirm/tok_1" {
 		t.Fatalf("unexpected confirm path %q", got)
@@ -128,12 +128,6 @@ func TestScopesAndBaseHelpers(t *testing.T) {
 	}
 
 	mb := &ModelBase{}
-	if err := mb.BeforeCreate(nil); err != nil {
-		t.Fatalf("model base before create failed: %v", err)
-	}
-	if mb.ID == "" {
-		t.Fatalf("expected generated model base id")
-	}
 	if err := mb.IsValid(); err != nil {
 		t.Fatalf("model base IsValid should initialize errors map: %v", err)
 	}
@@ -149,8 +143,8 @@ func TestClinicAndPatientValidationAndHelpers(t *testing.T) {
 	if err := clinic.BeforeCreate(nil); err != nil {
 		t.Fatalf("clinic before create should pass: %v", err)
 	}
-	if !strings.HasPrefix(clinic.ID, "clnc") {
-		t.Fatalf("expected clinic id prefix, got %q", clinic.ID)
+	if !strings.HasPrefix(clinic.UID, "clnc") {
+		t.Fatalf("expected clinic uid prefix, got %q", clinic.UID)
 	}
 	if clinic.AvatarPic() != "clinic.png" {
 		t.Fatalf("unexpected clinic avatar")
@@ -178,11 +172,11 @@ func TestClinicAndPatientValidationAndHelpers(t *testing.T) {
 
 	usr := User{ProfilePic: "u.png"}
 	if usr.IsLoggedIn() {
-		t.Fatalf("expected empty id to be not logged in")
+		t.Fatalf("expected empty uid to be not logged in")
 	}
-	usr.ID = "user_1"
+	usr.UID = "user_1"
 	if !usr.IsLoggedIn() {
-		t.Fatalf("expected id to indicate logged in")
+		t.Fatalf("expected uid to indicate logged in")
 	}
 	if usr.ProfilePicPath() != "u.png" || usr.AvatarPic() != "u.png" {
 		t.Fatalf("unexpected user avatar/profile methods")
@@ -240,7 +234,7 @@ func TestAppointmentAndIdentityHelpers(t *testing.T) {
 		t.Fatalf("expected unknown status to be invalid")
 	}
 
-	a := Appointment{ID: "apnt_1", Token: "tok_1", Timezone: "Invalid/Zone", BookedAt: time.Now().UTC()}
+	a := Appointment{UID: "apnt_1", Token: "tok_1", Timezone: "Invalid/Zone", BookedAt: time.Now().UTC()}
 	if got := a.LocalTimezone(); got != DefaultTimezone {
 		t.Fatalf("expected default timezone fallback, got %q", got)
 	}

--- a/internal/models/patient.go
+++ b/internal/models/patient.go
@@ -14,12 +14,13 @@ type Patient struct {
 	Address
 	SocialMedia
 	ModelBase
-	ID                string `gorm:"primarykey;default:null;not null" form:"_"`
+	ID                uint   `gorm:"primaryKey" form:"_"`
+	UID               string `gorm:"uniqueIndex;default:null;not null" form:"_"`
 	ExtID             string
 	Email             string         `form:"email"`
 	Phone             string         `form:"phone"`
 	Ocupation         string         `form:"ocupation"`
-	UserID            string         `gorm:"index;default:null;not null"`
+	UserID            uint           `gorm:"index;default:null;not null"`
 	Name              string         `gorm:"default:null;not null" form:"name"`
 	ProfilePic        string         `form:"profilePic"`
 	FamilyHistory     string         `form:"familyHistory"`
@@ -38,7 +39,7 @@ func (p *Patient) BeforeCreate(tx *gorm.DB) error {
 		return err
 	}
 
-	p.ID = xid.New("ptnt")
+	p.UID = xid.New("ptnt")
 	return nil
 }
 

--- a/internal/models/session.go
+++ b/internal/models/session.go
@@ -17,14 +17,16 @@ const (
 type Session struct {
 	ExpiresAt time.Time
 	ModelBase
+	ID       uint   `gorm:"primaryKey"`
+	UID      string `gorm:"uniqueIndex;default:null;not null"`
 	Token    string
 	Email    string      `gorm:"index;default:null;not null"`
-	UserID   string      `gorm:"index;default:null;not null"`
+	UserID   uint        `gorm:"index;default:null;not null"`
 	AuthType SessionType `gorm:"default:null;not null;type:string"`
 	User     User
 }
 
 func (u *Session) BeforeCreate(tx *gorm.DB) (err error) {
-	u.ID = xid.New("sess")
+	u.UID = xid.New("sess")
 	return nil
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -22,7 +22,8 @@ const (
 type User struct {
 	ConfirmEmailExpiresAt time.Time
 	ResetTokenExpiresAt   time.Time
-	ID                    string `gorm:"primarykey;default:null;not null" form:"__blank__"`
+	ID                    uint   `gorm:"primaryKey" form:"__blank__"`
+	UID                   string `gorm:"uniqueIndex;default:null;not null" form:"__blank__"`
 	ExtID                 string
 	ProfilePic            string
 	Name                  string
@@ -42,12 +43,12 @@ type User struct {
 }
 
 func (u *User) BeforeCreate(tx *gorm.DB) (err error) {
-	u.ID = xid.New("user")
+	u.UID = xid.New("user")
 	return nil
 }
 
 func (u User) IsLoggedIn() bool {
-	return u.ID != ""
+	return u.UID != ""
 }
 
 func (u User) Initials() string {

--- a/internal/server/request_test.go
+++ b/internal/server/request_test.go
@@ -14,15 +14,15 @@ func TestCurrentUser(t *testing.T) {
 	s := &Server{}
 
 	runWithCtx(t, http.MethodGet, "/", nil, func(c fiber.Ctx) {
-		if got := s.CurrentUser(c); got.ID != "" || got.Email != "" {
+		if got := s.CurrentUser(c); got.ID != 0 || got.Email != "" {
 			t.Fatalf("expected zero user when local is missing, got %#v", got)
 		}
 	})
 
 	runWithCtx(t, http.MethodGet, "/", nil, func(c fiber.Ctx) {
-		expected := models.User{ID: "usr_1", Email: "u@example.com"}
+		expected := models.User{UID: "usr_1", Email: "u@example.com"}
 		c.Locals("current_user", expected)
-		if got := s.CurrentUser(c); got.ID != expected.ID || got.Email != expected.Email {
+		if got := s.CurrentUser(c); got.UID != expected.UID || got.Email != expected.Email {
 			t.Fatalf("expected %#v, got %#v", expected, got)
 		}
 	})

--- a/internal/services/appointment/alerts.go
+++ b/internal/services/appointment/alerts.go
@@ -13,7 +13,7 @@ import (
 
 func (s *service) DispatchBookedAlert(appointment models.Appointment) error {
 	if s.Env.JobsEnabled {
-		payload := TaskAppointmentPayload{AppointmentID: appointment.ID}
+		payload := TaskAppointmentPayload{AppointmentID: appointment.UID}
 		_, err := s.EnqueueTask(context.Background(), TaskBookedAlert, payload)
 		return err
 	}
@@ -58,7 +58,7 @@ func (s *service) sendReminderNow(ctx context.Context, appointment models.Appoin
 	}
 
 	_, updateErr := gorm.G[models.Appointment](s.DB.GormDB()).
-		Where("id = ?", appointment.ID).
+		Where("uid = ?", appointment.UID).
 		Update(ctx, "ReminderAlertSentAt", time.Now())
 	if updateErr != nil {
 		fmt.Println("failed to update ReminderAlertSentAt:", updateErr.Error())
@@ -92,7 +92,7 @@ func (s *service) sendBookedNow(ctx context.Context, appointment models.Appointm
 		return
 	}
 	_, updateErr := gorm.G[models.Appointment](s.DB.GormDB()).
-		Where("id = ?", appointment.ID).
+		Where("uid = ?", appointment.UID).
 		Update(ctx, "BookedAlertSentAt", time.Now())
 	if updateErr != nil {
 		fmt.Println("failed to update BookedAlertSentAt:", updateErr.Error())

--- a/internal/services/appointment/alerts_jobs_test.go
+++ b/internal/services/appointment/alerts_jobs_test.go
@@ -46,7 +46,7 @@ func TestHandleBookedAlertTaskSkipsWhenAlreadySent(t *testing.T) {
 		t.Fatalf("create appointment: %v", err)
 	}
 
-	payload, err := json.Marshal(TaskAppointmentPayload{AppointmentID: apnt.ID})
+	payload, err := json.Marshal(TaskAppointmentPayload{AppointmentID: apnt.UID})
 	if err != nil {
 		t.Fatalf("marshal payload: %v", err)
 	}

--- a/internal/services/appointment/handlers.go
+++ b/internal/services/appointment/handlers.go
@@ -96,12 +96,12 @@ func (s *service) HandleStartPage(c fiber.Ctx) error {
 		return s.respondWithRedirect(c, redirectPath, fiber.StatusNotFound)
 	}
 
-	appointment, err := s.TakeAppointmentByID(c.Context(), cu.ID, appointmentID)
+	appointment, err := s.TakeAppointmentByUID(c.Context(), cu.ID, appointmentID)
 	if errors.Is(err, ErrIDRequired) {
 		redirectPath := "/appointments?toast=Invalid appointment id&level=error"
 		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
 	}
-	if errors.Is(err, gorm.ErrRecordNotFound) || appointment.ID == "" {
+	if errors.Is(err, gorm.ErrRecordNotFound) || appointment.ID == 0 {
 		redirectPath := "/appointments?toast=The appointment does not exist&level=warning"
 		return s.respondWithRedirect(c, redirectPath, fiber.StatusNotFound)
 	}
@@ -206,10 +206,23 @@ func (s *service) HandleCreate(c fiber.Ctx) error {
 		BookedMinute: bookedAt.Minute(),
 		Timezone:     models.DefaultTimezone,
 		Price:        amount.StrToAmount(priceValue),
-		ClinicID:     input.ClinicID,
-		PatientID:    input.PatientID,
+		ClinicID:     0,
+		PatientID:    0,
 		Duration:     input.Duration,
 	}
+
+	clinic, err := s.TakeClinicByUID(c.Context(), cu.ID, input.ClinicUID)
+	if err != nil {
+		redirectPath := "/appointments/new?toast=Invalid clinic selected&level=error"
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
+	}
+	patient, err := s.TakePatientByUID(c.Context(), cu.ID, input.PatientUID)
+	if err != nil {
+		redirectPath := "/appointments/new?toast=Invalid patient selected&level=error"
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
+	}
+	appointment.ClinicID = clinic.ID
+	appointment.PatientID = patient.ID
 
 	err = s.CreateAppointment(c.Context(), &appointment)
 	if err != nil {
@@ -217,7 +230,7 @@ func (s *service) HandleCreate(c fiber.Ctx) error {
 		return s.respondWithRedirect(c, redirectPath, fiber.StatusUnprocessableEntity)
 	}
 
-	appointment, err = s.TakeAppointmentByID(c.Context(), cu.ID, appointment.ID)
+	appointment, err = s.TakeAppointmentByUID(c.Context(), cu.ID, appointment.UID)
 	if err != nil {
 		redirectPath := "/appointments?toast=Appointment created, but failed to load related records"
 		return s.respondWithRedirect(c, redirectPath, fiber.StatusOK)
@@ -271,10 +284,23 @@ func (s *service) HandleUpdate(c fiber.Ctx) error {
 		BookedHour:   bookedAt.Hour(),
 		BookedMinute: bookedAt.Minute(),
 		Price:        amount.StrToAmount(c.FormValue("price", "")),
-		ClinicID:     input.ClinicID,
-		PatientID:    input.PatientID,
+		ClinicID:     0,
+		PatientID:    0,
 		Duration:     input.Duration,
 	}
+
+	clinic, err := s.TakeClinicByUID(c.Context(), cu.ID, input.ClinicUID)
+	if err != nil {
+		redirectPath := "/appointments/" + appointmentID + "?toast=Invalid clinic selected&level=error"
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
+	}
+	patient, err := s.TakePatientByUID(c.Context(), cu.ID, input.PatientUID)
+	if err != nil {
+		redirectPath := "/appointments/" + appointmentID + "?toast=Invalid patient selected&level=error"
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
+	}
+	appointment.ClinicID = clinic.ID
+	appointment.PatientID = patient.ID
 
 	err = s.UpdateAppointmentByID(c.Context(), cu.ID, appointmentID, appointment)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -453,8 +479,8 @@ func (s *service) HandlePriceFrg(c fiber.Ctx) error {
 	}
 
 	clinic, err := gorm.G[models.Clinic](s.DB.GormDB()).
-		Select("id", "price").
-		Where("id = ? AND user_id = ?", clinicID, cu.ID).
+		Select("id", "uid", "price").
+		Where("uid = ? AND user_id = ?", clinicID, cu.ID).
 		Take(c.Context())
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return c.SendStatus(fiber.StatusNotFound)
@@ -487,26 +513,24 @@ func (s *service) HandleSearchClinics(c fiber.Ctx) error {
 	return view.Render(c, view.ApptSearchClinicsFrg(vc, clinics))
 }
 
-func (s *service) AppointmentForShowPage(ctx context.Context, userID, appointmentID string) (models.Appointment, error) {
-	appointment := models.Appointment{ID: appointmentID}
+func (s *service) AppointmentForShowPage(ctx context.Context, userID uint, appointmentID string) (models.Appointment, error) {
+	appointment := models.Appointment{UID: appointmentID}
 	if appointmentID == "" || appointmentID == "new" {
 		return appointment, nil
 	}
 
-	return s.TakeAppointmentByID(ctx, userID, appointmentID)
+	return s.TakeAppointmentByUID(ctx, userID, appointmentID)
 }
 
-func (s *service) PatientForStartPage(ctx context.Context, userID, patientID string) (models.Patient, error) {
-	return s.TakePatientByIDWithLastDoneAppointment(ctx, userID, patientID)
-}
-
-func (s *service) selectedPatientFromQuery(c fiber.Ctx, userID, patientID string) (models.Patient, error) {
-	patientID = strings.TrimSpace(patientID)
-	if patientID == "" {
-		return models.Patient{}, nil
-	}
-
-	patient, err := s.TakePatientByID(c.Context(), userID, patientID)
+func (s *service) PatientForStartPage(ctx context.Context, userID, patientID uint) (models.Patient, error) {
+	patient := models.Patient{}
+	err := s.DB.WithContext(ctx).
+		Model(&models.Patient{}).
+		Where("id = ? AND user_id = ?", patientID, userID).
+		Preload("Appointments", func(tx *gorm.DB) *gorm.DB {
+			return tx.Limit(1).Where("status = ?", models.ApntStatusDone).Order("booked_at desc")
+		}).
+		Take(&patient).Error
 	if err != nil {
 		return models.Patient{}, err
 	}
@@ -514,13 +538,27 @@ func (s *service) selectedPatientFromQuery(c fiber.Ctx, userID, patientID string
 	return patient, nil
 }
 
-func (s *service) selectedClinicFromQuery(c fiber.Ctx, userID, clinicID string) (models.Clinic, error) {
+func (s *service) selectedPatientFromQuery(c fiber.Ctx, userID uint, patientID string) (models.Patient, error) {
+	patientID = strings.TrimSpace(patientID)
+	if patientID == "" {
+		return models.Patient{}, nil
+	}
+
+	patient, err := s.TakePatientByUID(c.Context(), userID, patientID)
+	if err != nil {
+		return models.Patient{}, err
+	}
+
+	return patient, nil
+}
+
+func (s *service) selectedClinicFromQuery(c fiber.Ctx, userID uint, clinicID string) (models.Clinic, error) {
 	clinicID = strings.TrimSpace(clinicID)
 	if clinicID == "" {
 		return models.Clinic{}, nil
 	}
 
-	clinic, err := s.TakeClinicByID(c.Context(), userID, clinicID)
+	clinic, err := s.TakeClinicByUID(c.Context(), userID, clinicID)
 	if err != nil {
 		return models.Clinic{}, err
 	}

--- a/internal/services/appointment/handlers.go
+++ b/internal/services/appointment/handlers.go
@@ -214,12 +214,12 @@ func (s *service) HandleCreate(c fiber.Ctx) error {
 	clinic, err := s.TakeClinicByUID(c.Context(), cu.ID, input.ClinicUID)
 	if err != nil {
 		redirectPath := "/appointments/new?toast=Invalid clinic selected&level=error"
-		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusUnprocessableEntity)
 	}
 	patient, err := s.TakePatientByUID(c.Context(), cu.ID, input.PatientUID)
 	if err != nil {
 		redirectPath := "/appointments/new?toast=Invalid patient selected&level=error"
-		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusUnprocessableEntity)
 	}
 	appointment.ClinicID = clinic.ID
 	appointment.PatientID = patient.ID
@@ -261,6 +261,16 @@ func (s *service) HandleUpdate(c fiber.Ctx) error {
 		return s.Redirect(c, "/appointments?msg=can't update without an id")
 	}
 
+	_, err := s.TakeAppointmentByUID(c.Context(), cu.ID, appointmentID)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		redirectPath := "/appointments?toast=The appointment does not exist&level=warning"
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusNotFound)
+	}
+	if err != nil {
+		redirectPath := "/appointments/" + appointmentID + "?toast=Failed to load appointment&level=error"
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusUnprocessableEntity)
+	}
+
 	bookedAtStr := c.FormValue("bookedAt", "")
 	bookedAt, err := time.Parse(view.FormTimeFormat, bookedAtStr)
 	if err != nil {
@@ -292,12 +302,12 @@ func (s *service) HandleUpdate(c fiber.Ctx) error {
 	clinic, err := s.TakeClinicByUID(c.Context(), cu.ID, input.ClinicUID)
 	if err != nil {
 		redirectPath := "/appointments/" + appointmentID + "?toast=Invalid clinic selected&level=error"
-		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusUnprocessableEntity)
 	}
 	patient, err := s.TakePatientByUID(c.Context(), cu.ID, input.PatientUID)
 	if err != nil {
 		redirectPath := "/appointments/" + appointmentID + "?toast=Invalid patient selected&level=error"
-		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusUnprocessableEntity)
 	}
 	appointment.ClinicID = clinic.ID
 	appointment.PatientID = patient.ID

--- a/internal/services/appointment/handlers_flow_test.go
+++ b/internal/services/appointment/handlers_flow_test.go
@@ -43,7 +43,7 @@ func TestAppointmentHandlersFlows(t *testing.T) {
 			t.Fatalf("index page expected 200, got status=%d err=%v", resp1.StatusCode, err)
 		}
 
-		resp2, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+apnt.ID, nil))
+		resp2, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+apnt.UID, nil))
 		if err != nil || resp2.StatusCode != fiber.StatusOK {
 			t.Fatalf("show page expected 200, got status=%d err=%v", resp2.StatusCode, err)
 		}
@@ -84,7 +84,7 @@ func TestAppointmentHandlersFlows(t *testing.T) {
 			return svc.HandleSearchClinics(c)
 		})
 
-		resp1, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+apnt.ID+"/start", nil))
+		resp1, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+apnt.UID+"/start", nil))
 		if err != nil || resp1.StatusCode != fiber.StatusOK {
 			t.Fatalf("start page expected 200, got status=%d err=%v", resp1.StatusCode, err)
 		}
@@ -92,8 +92,8 @@ func TestAppointmentHandlersFlows(t *testing.T) {
 		form := url.Values{
 			"bookedAt":  {time.Now().Format("2006-01-02T15:04")},
 			"price":     {"100.0"},
-			"clinicId":  {clinic.ID},
-			"patientId": {patient.ID},
+			"clinicId":  {clinic.UID},
+			"patientId": {patient.UID},
 			"duration":  {"30"},
 		}
 		req2 := httptest.NewRequest(http.MethodPost, "/appointments", strings.NewReader(form.Encode()))
@@ -106,11 +106,11 @@ func TestAppointmentHandlersFlows(t *testing.T) {
 		updForm := url.Values{
 			"bookedAt":  {time.Now().Add(2 * time.Hour).Format("2006-01-02T15:04")},
 			"price":     {"120.0"},
-			"clinicId":  {clinic.ID},
-			"patientId": {patient.ID},
+			"clinicId":  {clinic.UID},
+			"patientId": {patient.UID},
 			"duration":  {"45"},
 		}
-		req3 := httptest.NewRequest(http.MethodPost, "/appointments/"+apnt.ID+"/patch", strings.NewReader(updForm.Encode()))
+		req3 := httptest.NewRequest(http.MethodPost, "/appointments/"+apnt.UID+"/patch", strings.NewReader(updForm.Encode()))
 		req3.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		resp3, err := app.Test(req3)
 		if err != nil || resp3.StatusCode != fiber.StatusSeeOther {
@@ -123,19 +123,19 @@ func TestAppointmentHandlersFlows(t *testing.T) {
 			"summary":      {"ok"},
 			"notes":        {"notes"},
 		}
-		req4 := httptest.NewRequest(http.MethodPost, "/appointments/"+apnt.ID+"/complete", strings.NewReader(completeForm.Encode()))
+		req4 := httptest.NewRequest(http.MethodPost, "/appointments/"+apnt.UID+"/complete", strings.NewReader(completeForm.Encode()))
 		req4.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		resp4, err := app.Test(req4)
 		if err != nil || resp4.StatusCode != fiber.StatusSeeOther {
 			t.Fatalf("complete expected 303, got status=%d err=%v", resp4.StatusCode, err)
 		}
 
-		resp5, err := app.Test(httptest.NewRequest(http.MethodPost, "/appointments/"+apnt.ID+"/cancel", nil))
+		resp5, err := app.Test(httptest.NewRequest(http.MethodPost, "/appointments/"+apnt.UID+"/cancel", nil))
 		if err != nil || resp5.StatusCode != fiber.StatusSeeOther {
 			t.Fatalf("cancel expected 303, got status=%d err=%v", resp5.StatusCode, err)
 		}
 
-		resp6, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/new/pricefrg/"+clinic.ID, nil))
+		resp6, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/new/pricefrg/"+clinic.UID, nil))
 		if err != nil || resp6.StatusCode != fiber.StatusOK {
 			t.Fatalf("price fragment expected 200, got status=%d err=%v", resp6.StatusCode, err)
 		}
@@ -147,7 +147,7 @@ func TestAppointmentHandlersFlows(t *testing.T) {
 			t.Fatalf("search clinics expected 200, got status=%d err=%v", resp7.StatusCode, err)
 		}
 
-		resp8, err := app.Test(httptest.NewRequest(http.MethodPost, "/appointments/"+apnt.ID+"/delete", nil))
+		resp8, err := app.Test(httptest.NewRequest(http.MethodPost, "/appointments/"+apnt.UID+"/delete", nil))
 		if err != nil || resp8.StatusCode != fiber.StatusSeeOther {
 			t.Fatalf("delete expected 303, got status=%d err=%v", resp8.StatusCode, err)
 		}
@@ -171,22 +171,22 @@ func TestAppointmentHandlersFlows(t *testing.T) {
 		app.Post("/appointments/:id/patient/cancel/:token", svc.HandlePatientCancel)
 		app.Get("/appointments/:id/patient/changedate/:token", svc.HandlePatientChangeDate)
 
-		resp1, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+tokenApnt.ID+"/patient/confirm/"+tokenApnt.Token, nil))
+		resp1, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+tokenApnt.UID+"/patient/confirm/"+tokenApnt.Token, nil))
 		if err != nil || resp1.StatusCode != fiber.StatusOK {
 			t.Fatalf("patient confirm expected 200, got status=%d err=%v", resp1.StatusCode, err)
 		}
 
-		resp2, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+tokenApnt.ID+"/patient/cancel/"+tokenApnt.Token, nil))
+		resp2, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+tokenApnt.UID+"/patient/cancel/"+tokenApnt.Token, nil))
 		if err != nil || resp2.StatusCode != fiber.StatusOK {
 			t.Fatalf("patient cancel page expected 200, got status=%d err=%v", resp2.StatusCode, err)
 		}
 
-		resp3, err := app.Test(httptest.NewRequest(http.MethodPost, "/appointments/"+tokenApnt.ID+"/patient/cancel/"+tokenApnt.Token, nil))
+		resp3, err := app.Test(httptest.NewRequest(http.MethodPost, "/appointments/"+tokenApnt.UID+"/patient/cancel/"+tokenApnt.Token, nil))
 		if err != nil || resp3.StatusCode != fiber.StatusOK {
 			t.Fatalf("patient cancel expected 200, got status=%d err=%v", resp3.StatusCode, err)
 		}
 
-		resp4, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+tokenApnt.ID+"/patient/changedate/"+tokenApnt.Token, nil))
+		resp4, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+tokenApnt.UID+"/patient/changedate/"+tokenApnt.Token, nil))
 		if err != nil || resp4.StatusCode != fiber.StatusOK {
 			t.Fatalf("patient change date expected 200, got status=%d err=%v", resp4.StatusCode, err)
 		}
@@ -280,7 +280,7 @@ func TestHandleStartPagePatientMissingBranch(t *testing.T) {
 	apnt := models.Appointment{
 		UserID:    user.ID,
 		ClinicID:  clinic.ID,
-		PatientID: "missing-patient-id",
+		PatientID: 999999,
 		BookedAt:  time.Now().Add(time.Hour),
 		Token:     "tok_missing_patient",
 	}
@@ -294,7 +294,7 @@ func TestHandleStartPagePatientMissingBranch(t *testing.T) {
 		return svc.HandleStartPage(c)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+apnt.ID+"/start", nil))
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/appointments/"+apnt.UID+"/start", nil))
 	if err != nil || resp.StatusCode != fiber.StatusSeeOther {
 		t.Fatalf("start with missing patient expected 303 redirect, got status=%d err=%v", resp.StatusCode, err)
 	}

--- a/internal/services/appointment/handlers_helpers_test.go
+++ b/internal/services/appointment/handlers_helpers_test.go
@@ -17,20 +17,20 @@ func TestAppointmentForShowPage(t *testing.T) {
 	svc := &service{}
 	ctx := context.Background()
 
-	appointment, err := svc.AppointmentForShowPage(ctx, "usr_1", "")
+	appointment, err := svc.AppointmentForShowPage(ctx, 1, "")
 	if err != nil {
 		t.Fatalf("expected empty-id shortcut without error, got %v", err)
 	}
-	if appointment.ID != "" {
-		t.Fatalf("expected zero-value appointment id, got %q", appointment.ID)
+	if appointment.UID != "" {
+		t.Fatalf("expected zero-value appointment uid, got %q", appointment.UID)
 	}
 
-	appointment, err = svc.AppointmentForShowPage(ctx, "usr_1", "new")
+	appointment, err = svc.AppointmentForShowPage(ctx, 1, "new")
 	if err != nil {
 		t.Fatalf("expected new-id shortcut without error, got %v", err)
 	}
-	if appointment.ID != "new" {
-		t.Fatalf("expected passthrough appointment id, got %q", appointment.ID)
+	if appointment.UID != "new" {
+		t.Fatalf("expected passthrough appointment uid, got %q", appointment.UID)
 	}
 }
 
@@ -38,20 +38,20 @@ func TestPatientAndClinicSelectionHelpers(t *testing.T) {
 	svc := &service{}
 	app := fiber.New()
 	app.Get("/", func(c fiber.Ctx) error {
-		patient, err := svc.selectedPatientFromQuery(c, "usr_1", "   ")
+		patient, err := svc.selectedPatientFromQuery(c, 1, "   ")
 		if err != nil {
 			t.Fatalf("expected blank patient query to skip lookup, got %v", err)
 		}
-		if patient.ID != "" {
-			t.Fatalf("expected zero patient when query is blank, got %q", patient.ID)
+		if patient.ID != 0 {
+			t.Fatalf("expected zero patient when query is blank, got %d", patient.ID)
 		}
 
-		clinic, err := svc.selectedClinicFromQuery(c, "usr_1", "")
+		clinic, err := svc.selectedClinicFromQuery(c, 1, "")
 		if err != nil {
 			t.Fatalf("expected blank clinic query to skip lookup, got %v", err)
 		}
-		if clinic.ID != "" {
-			t.Fatalf("expected zero clinic when query is blank, got %q", clinic.ID)
+		if clinic.ID != 0 {
+			t.Fatalf("expected zero clinic when query is blank, got %d", clinic.ID)
 		}
 
 		return c.SendStatus(fiber.StatusNoContent)
@@ -72,20 +72,20 @@ func TestSelectionHelpersBranchesAndNotFoundPage(t *testing.T) {
 	t.Run("selected helpers return entities when ids exist", func(t *testing.T) {
 		app := fiber.New()
 		app.Get("/", func(c fiber.Ctx) error {
-			gotPatient, err := svc.selectedPatientFromQuery(c, user.ID, patient.ID)
+			gotPatient, err := svc.selectedPatientFromQuery(c, user.ID, patient.UID)
 			if err != nil {
 				t.Fatalf("expected selected patient success, got %v", err)
 			}
 			if gotPatient.ID != patient.ID {
-				t.Fatalf("expected patient id %q, got %q", patient.ID, gotPatient.ID)
+				t.Fatalf("expected patient id %d, got %d", patient.ID, gotPatient.ID)
 			}
 
-			gotClinic, err := svc.selectedClinicFromQuery(c, user.ID, clinic.ID)
+			gotClinic, err := svc.selectedClinicFromQuery(c, user.ID, clinic.UID)
 			if err != nil {
 				t.Fatalf("expected selected clinic success, got %v", err)
 			}
 			if gotClinic.ID != clinic.ID {
-				t.Fatalf("expected clinic id %q, got %q", clinic.ID, gotClinic.ID)
+				t.Fatalf("expected clinic id %d, got %d", clinic.ID, gotClinic.ID)
 			}
 
 			return c.SendStatus(fiber.StatusNoContent)

--- a/internal/services/appointment/inputs.go
+++ b/internal/services/appointment/inputs.go
@@ -1,9 +1,9 @@
 package appointment
 
 type appointmentUpsertInput struct {
-	ClinicID  string `form:"clinicId"`
-	PatientID string `form:"patientId"`
-	Duration  int    `form:"duration"`
+	ClinicUID  string `form:"clinicId"`
+	PatientUID string `form:"patientId"`
+	Duration   int    `form:"duration"`
 }
 
 type appointmentCompleteInput struct {

--- a/internal/services/appointment/jobs.go
+++ b/internal/services/appointment/jobs.go
@@ -77,8 +77,8 @@ func (s *service) handleReminderSweepTask(ctx context.Context, _ jobs.Task) erro
 	}
 
 	for _, appointment := range appointments {
-		if _, err := s.EnqueueTask(ctx, TaskReminder, TaskAppointmentPayload{AppointmentID: appointment.ID}); err != nil {
-			log.Printf("appointment jobs: enqueue reminder failed for %s: %v", appointment.ID, err)
+		if _, err := s.EnqueueTask(ctx, TaskReminder, TaskAppointmentPayload{AppointmentID: appointment.UID}); err != nil {
+			log.Printf("appointment jobs: enqueue reminder failed for %s: %v", appointment.UID, err)
 		}
 	}
 
@@ -97,7 +97,7 @@ func (s *service) handleReminderTask(ctx context.Context, task jobs.Task) error 
 	appointment, err := gorm.G[models.Appointment](s.DB.GormDB()).
 		Preload("Patient", nil).
 		Preload("Clinic", nil).
-		Where("id = ?", payload.AppointmentID).
+		Where("uid = ?", payload.AppointmentID).
 		First(ctx)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil
@@ -126,7 +126,7 @@ func (s *service) handleBookedAlertTask(ctx context.Context, task jobs.Task) err
 	appointment, err := gorm.G[models.Appointment](s.DB.GormDB()).
 		Preload("Patient", nil).
 		Preload("Clinic", nil).
-		Where("id = ?", payload.AppointmentID).
+		Where("uid = ?", payload.AppointmentID).
 		First(ctx)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil

--- a/internal/services/appointment/service.go
+++ b/internal/services/appointment/service.go
@@ -38,13 +38,13 @@ func New(s *server.Server) (*service, error) {
 	return svc, nil
 }
 
-func (s *service) TakePatientByID(ctx context.Context, userID, patientID string) (models.Patient, error) {
+func (s *service) TakePatientByID(ctx context.Context, userID uint, patientID string) (models.Patient, error) {
 	if strings.TrimSpace(patientID) == "" {
 		return models.Patient{}, ErrIDRequired
 	}
 
 	patient, err := gorm.G[models.Patient](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientID, userID).
 		Take(ctx)
 	if err != nil {
 		return models.Patient{}, err
@@ -53,13 +53,13 @@ func (s *service) TakePatientByID(ctx context.Context, userID, patientID string)
 	return patient, nil
 }
 
-func (s *service) TakeClinicByID(ctx context.Context, userID, clinicID string) (models.Clinic, error) {
+func (s *service) TakeClinicByID(ctx context.Context, userID uint, clinicID string) (models.Clinic, error) {
 	if strings.TrimSpace(clinicID) == "" {
 		return models.Clinic{}, ErrIDRequired
 	}
 
 	clinic, err := gorm.G[models.Clinic](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", clinicID, userID).
+		Where("uid = ? AND user_id = ?", clinicID, userID).
 		Take(ctx)
 	if err != nil {
 		return models.Clinic{}, err
@@ -84,7 +84,7 @@ func (s *service) CreateAppointment(ctx context.Context, appointment *models.App
 	return gorm.G[models.Appointment](s.DB.GormDB()).Create(ctx, appointment)
 }
 
-func (s *service) TakeAppointmentByID(ctx context.Context, userID, appointmentID string) (models.Appointment, error) {
+func (s *service) TakeAppointmentByID(ctx context.Context, userID uint, appointmentID string) (models.Appointment, error) {
 	if strings.TrimSpace(appointmentID) == "" {
 		return models.Appointment{}, ErrIDRequired
 	}
@@ -92,7 +92,7 @@ func (s *service) TakeAppointmentByID(ctx context.Context, userID, appointmentID
 	appointment, err := gorm.G[models.Appointment](s.DB.GormDB()).
 		Preload("Clinic", nil).
 		Preload("Patient", nil).
-		Where("id = ? AND user_id = ?", appointmentID, userID).
+		Where("uid = ? AND user_id = ?", appointmentID, userID).
 		Take(ctx)
 	if err != nil {
 		return models.Appointment{}, err
@@ -101,7 +101,7 @@ func (s *service) TakeAppointmentByID(ctx context.Context, userID, appointmentID
 	return appointment, nil
 }
 
-func (s *service) UpdateAppointmentByID(ctx context.Context, userID, appointmentID string, updates appointmentPatchUpdates) error {
+func (s *service) UpdateAppointmentByID(ctx context.Context, userID uint, appointmentID string, updates appointmentPatchUpdates) error {
 	if strings.TrimSpace(appointmentID) == "" {
 		return ErrIDRequired
 	}
@@ -122,7 +122,7 @@ func (s *service) UpdateAppointmentByID(ctx context.Context, userID, appointment
 	return s.updateAppointmentColumnsByID(ctx, userID, appointmentID, columns, &updates)
 }
 
-func (s *service) CompleteAppointmentByID(ctx context.Context, userID, appointmentID string, updates appointmentCompleteUpdates) error {
+func (s *service) CompleteAppointmentByID(ctx context.Context, userID uint, appointmentID string, updates appointmentCompleteUpdates) error {
 	if strings.TrimSpace(appointmentID) == "" {
 		return ErrIDRequired
 	}
@@ -136,7 +136,7 @@ func (s *service) CompleteAppointmentByID(ctx context.Context, userID, appointme
 	return s.updateAppointmentColumnsByID(ctx, userID, appointmentID, columns, &updates)
 }
 
-func (s *service) CancelAppointmentByID(ctx context.Context, userID, appointmentID string, updates appointmentCancelUpdates) error {
+func (s *service) CancelAppointmentByID(ctx context.Context, userID uint, appointmentID string, updates appointmentCancelUpdates) error {
 	if strings.TrimSpace(appointmentID) == "" {
 		return ErrIDRequired
 	}
@@ -150,14 +150,14 @@ func (s *service) CancelAppointmentByID(ctx context.Context, userID, appointment
 	return s.updateAppointmentColumnsByID(ctx, userID, appointmentID, columns, &updates)
 }
 
-func (s *service) updateAppointmentColumnsByID(ctx context.Context, userID, appointmentID string, columns []string, updates any) error {
+func (s *service) updateAppointmentColumnsByID(ctx context.Context, userID uint, appointmentID string, columns []string, updates any) error {
 	if len(columns) == 0 {
 		return errors.New("columns are required")
 	}
 
 	result := s.DB.WithContext(ctx).
 		Model(&models.Appointment{}).
-		Where("id = ? AND user_id = ?", appointmentID, userID).
+		Where("uid = ? AND user_id = ?", appointmentID, userID).
 		Select(columns).
 		Omit("UserID", "Clinic", "Patient", "User", "FeedEvents", "Alerts").
 		Updates(updates)
@@ -171,13 +171,13 @@ func (s *service) updateAppointmentColumnsByID(ctx context.Context, userID, appo
 	return nil
 }
 
-func (s *service) DeleteAppointmentByID(ctx context.Context, userID, appointmentID string) error {
+func (s *service) DeleteAppointmentByID(ctx context.Context, userID uint, appointmentID string) error {
 	if strings.TrimSpace(appointmentID) == "" {
 		return ErrIDRequired
 	}
 
 	rowsAffected, err := gorm.G[models.Appointment](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", appointmentID, userID).
+		Where("uid = ? AND user_id = ?", appointmentID, userID).
 		Delete(ctx)
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func (s *service) TakeAppointmentByIDAndToken(ctx context.Context, appointmentID
 	appointment, err := gorm.G[models.Appointment](s.DB.GormDB()).
 		Preload("Clinic", nil).
 		Preload("User", nil).
-		Where("id = ? AND token = ?", appointmentID, token).
+		Where("uid = ? AND token = ?", appointmentID, token).
 		Take(ctx)
 	if err != nil {
 		return models.Appointment{}, err
@@ -202,14 +202,14 @@ func (s *service) TakeAppointmentByIDAndToken(ctx context.Context, appointmentID
 	return appointment, nil
 }
 
-func (s *service) TakePatientByIDWithLastDoneAppointment(ctx context.Context, userID, patientID string) (models.Patient, error) {
+func (s *service) TakePatientByIDWithLastDoneAppointment(ctx context.Context, userID uint, patientID string) (models.Patient, error) {
 	if strings.TrimSpace(patientID) == "" {
 		return models.Patient{}, ErrIDRequired
 	}
 
 	patient := models.Patient{}
 	err := s.DB.Model(&models.Patient{}).
-		Where("id = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientID, userID).
 		Preload("Appointments", func(tx *gorm.DB) *gorm.DB {
 			return tx.Limit(1).Where("status = ?", models.ApntStatusDone).Order("booked_at desc")
 		}).
@@ -236,7 +236,7 @@ func (s *service) UpdateAppointmentByIDAndToken(ctx context.Context, appointment
 
 	result := s.DB.WithContext(ctx).
 		Model(&models.Appointment{}).
-		Where("id = ? AND token = ?", appointmentID, token).
+		Where("uid = ? AND token = ?", appointmentID, token).
 		Select(selectColumns).
 		Omit("UserID", "Clinic", "Patient", "User", "FeedEvents", "Alerts").
 		Updates(&updates)
@@ -274,16 +274,16 @@ func (s *service) RequestAppointmentDateChangeByIDAndToken(ctx context.Context, 
 	return s.UpdateAppointmentByIDAndToken(ctx, appointmentID, token, []string{"PendingAt", "Status"}, updates)
 }
 
-func (s *service) FindAppointmentsBy(ctx context.Context, userID, patientID, clinicID, timeframe string) ([]models.Appointment, error) {
+func (s *service) FindAppointmentsBy(ctx context.Context, userID uint, patientID, clinicID, timeframe string) ([]models.Appointment, error) {
 	appointments := []models.Appointment{}
 	dbquery := s.DB.Model(&models.Appointment{}).Where("user_id = ?", userID)
 
 	if patientID != "" {
-		dbquery = dbquery.Where("patient_id = ?", patientID)
+		dbquery = dbquery.Joins("INNER JOIN patients ON patients.id = appointments.patient_id").Where("patients.uid = ?", patientID)
 	}
 
 	if clinicID != "" {
-		dbquery = dbquery.Where("clinic_id = ?", clinicID)
+		dbquery = dbquery.Joins("INNER JOIN clinics ON clinics.id = appointments.clinic_id").Where("clinics.uid = ?", clinicID)
 	}
 
 	switch timeframe {
@@ -309,7 +309,7 @@ func (s *service) FindAppointmentsBy(ctx context.Context, userID, patientID, cli
 	return appointments, nil
 }
 
-func (s *service) FindClinicsBySearchTerm(ctx context.Context, userID, searchTerm string) ([]models.Clinic, error) {
+func (s *service) FindClinicsBySearchTerm(ctx context.Context, userID uint, searchTerm string) ([]models.Clinic, error) {
 	clinics := []models.Clinic{}
 	searchTerm = strings.TrimSpace(searchTerm)
 	err := s.DB.WithContext(ctx).
@@ -326,7 +326,7 @@ func (s *service) FindClinicsBySearchTerm(ctx context.Context, userID, searchTer
 	return clinics, nil
 }
 
-func (s *service) FindRecentClinicsByUserID(ctx context.Context, userID string, limit int) ([]models.Clinic, error) {
+func (s *service) FindRecentClinicsByUserID(ctx context.Context, userID uint, limit int) ([]models.Clinic, error) {
 	clinics := []models.Clinic{}
 	err := s.DB.WithContext(ctx).
 		Model(&models.Clinic{}).
@@ -342,7 +342,7 @@ func (s *service) FindRecentClinicsByUserID(ctx context.Context, userID string, 
 	return clinics, nil
 }
 
-func (s *service) FindRecentPatientsByUserID(ctx context.Context, userID string, limit int) ([]models.Patient, error) {
+func (s *service) FindRecentPatientsByUserID(ctx context.Context, userID uint, limit int) ([]models.Patient, error) {
 	patients := []models.Patient{}
 	err := s.DB.WithContext(ctx).
 		Model(&models.Patient{}).

--- a/internal/services/appointment/service.go
+++ b/internal/services/appointment/service.go
@@ -38,13 +38,13 @@ func New(s *server.Server) (*service, error) {
 	return svc, nil
 }
 
-func (s *service) TakePatientByID(ctx context.Context, userID uint, patientID string) (models.Patient, error) {
-	if strings.TrimSpace(patientID) == "" {
+func (s *service) TakePatientByUID(ctx context.Context, userID uint, patientUID string) (models.Patient, error) {
+	if strings.TrimSpace(patientUID) == "" {
 		return models.Patient{}, ErrIDRequired
 	}
 
 	patient, err := gorm.G[models.Patient](s.DB.GormDB()).
-		Where("uid = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientUID, userID).
 		Take(ctx)
 	if err != nil {
 		return models.Patient{}, err
@@ -53,13 +53,13 @@ func (s *service) TakePatientByID(ctx context.Context, userID uint, patientID st
 	return patient, nil
 }
 
-func (s *service) TakeClinicByID(ctx context.Context, userID uint, clinicID string) (models.Clinic, error) {
-	if strings.TrimSpace(clinicID) == "" {
+func (s *service) TakeClinicByUID(ctx context.Context, userID uint, clinicUID string) (models.Clinic, error) {
+	if strings.TrimSpace(clinicUID) == "" {
 		return models.Clinic{}, ErrIDRequired
 	}
 
 	clinic, err := gorm.G[models.Clinic](s.DB.GormDB()).
-		Where("uid = ? AND user_id = ?", clinicID, userID).
+		Where("uid = ? AND user_id = ?", clinicUID, userID).
 		Take(ctx)
 	if err != nil {
 		return models.Clinic{}, err
@@ -84,15 +84,15 @@ func (s *service) CreateAppointment(ctx context.Context, appointment *models.App
 	return gorm.G[models.Appointment](s.DB.GormDB()).Create(ctx, appointment)
 }
 
-func (s *service) TakeAppointmentByID(ctx context.Context, userID uint, appointmentID string) (models.Appointment, error) {
-	if strings.TrimSpace(appointmentID) == "" {
+func (s *service) TakeAppointmentByUID(ctx context.Context, userID uint, appointmentUID string) (models.Appointment, error) {
+	if strings.TrimSpace(appointmentUID) == "" {
 		return models.Appointment{}, ErrIDRequired
 	}
 
 	appointment, err := gorm.G[models.Appointment](s.DB.GormDB()).
 		Preload("Clinic", nil).
 		Preload("Patient", nil).
-		Where("uid = ? AND user_id = ?", appointmentID, userID).
+		Where("uid = ? AND user_id = ?", appointmentUID, userID).
 		Take(ctx)
 	if err != nil {
 		return models.Appointment{}, err
@@ -202,14 +202,14 @@ func (s *service) TakeAppointmentByIDAndToken(ctx context.Context, appointmentID
 	return appointment, nil
 }
 
-func (s *service) TakePatientByIDWithLastDoneAppointment(ctx context.Context, userID uint, patientID string) (models.Patient, error) {
-	if strings.TrimSpace(patientID) == "" {
+func (s *service) TakePatientByUIDWithLastDoneAppointment(ctx context.Context, userID uint, patientUID string) (models.Patient, error) {
+	if strings.TrimSpace(patientUID) == "" {
 		return models.Patient{}, ErrIDRequired
 	}
 
 	patient := models.Patient{}
 	err := s.DB.Model(&models.Patient{}).
-		Where("uid = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientUID, userID).
 		Preload("Appointments", func(tx *gorm.DB) *gorm.DB {
 			return tx.Limit(1).Where("status = ?", models.ApntStatusDone).Order("booked_at desc")
 		}).
@@ -276,7 +276,7 @@ func (s *service) RequestAppointmentDateChangeByIDAndToken(ctx context.Context, 
 
 func (s *service) FindAppointmentsBy(ctx context.Context, userID uint, patientID, clinicID, timeframe string) ([]models.Appointment, error) {
 	appointments := []models.Appointment{}
-	dbquery := s.DB.Model(&models.Appointment{}).Where("user_id = ?", userID)
+	dbquery := s.DB.Model(&models.Appointment{}).Where("appointments.user_id = ?", userID)
 
 	if patientID != "" {
 		dbquery = dbquery.Joins("INNER JOIN patients ON patients.id = appointments.patient_id").Where("patients.uid = ?", patientID)

--- a/internal/services/appointment/service_db_test.go
+++ b/internal/services/appointment/service_db_test.go
@@ -34,20 +34,20 @@ func TestAppointmentServiceDBFlows(t *testing.T) {
 			t.Fatalf("expected default pending status, got %q", apnt.Status)
 		}
 
-		got, err := svc.TakeAppointmentByID(ctx, user.ID, apnt.ID)
+		got, err := svc.TakeAppointmentByUID(ctx, user.ID, apnt.UID)
 		if err != nil {
 			t.Fatalf("take appointment: %v", err)
 		}
-		if got.ID != apnt.ID || got.Clinic.ID == "" || got.Patient.ID == "" {
+		if got.ID != apnt.ID || got.Clinic.ID == 0 || got.Patient.ID == 0 {
 			t.Fatalf("expected preloaded appointment entities")
 		}
 	})
 
 	t.Run("lookups by ids work", func(t *testing.T) {
-		if _, err := svc.TakePatientByID(ctx, user.ID, patient.ID); err != nil {
+		if _, err := svc.TakePatientByUID(ctx, user.ID, patient.UID); err != nil {
 			t.Fatalf("take patient by id: %v", err)
 		}
-		if _, err := svc.TakeClinicByID(ctx, user.ID, clinic.ID); err != nil {
+		if _, err := svc.TakeClinicByUID(ctx, user.ID, clinic.UID); err != nil {
 			t.Fatalf("take clinic by id: %v", err)
 		}
 	})
@@ -65,17 +65,17 @@ func TestAppointmentServiceDBFlows(t *testing.T) {
 			t.Fatalf("create appointment: %v", err)
 		}
 
-		if err := svc.ConfirmAppointmentByIDAndToken(ctx, apnt.ID, apnt.Token); err != nil {
+		if err := svc.ConfirmAppointmentByIDAndToken(ctx, apnt.UID, apnt.Token); err != nil {
 			t.Fatalf("confirm by token: %v", err)
 		}
-		if err := svc.CancelAppointmentByIDAndToken(ctx, apnt.ID, apnt.Token); err != nil {
+		if err := svc.CancelAppointmentByIDAndToken(ctx, apnt.UID, apnt.Token); err != nil {
 			t.Fatalf("cancel by token: %v", err)
 		}
-		if err := svc.RequestAppointmentDateChangeByIDAndToken(ctx, apnt.ID, apnt.Token); err != nil {
+		if err := svc.RequestAppointmentDateChangeByIDAndToken(ctx, apnt.UID, apnt.Token); err != nil {
 			t.Fatalf("request date change by token: %v", err)
 		}
 
-		got, err := svc.TakeAppointmentByIDAndToken(ctx, apnt.ID, apnt.Token)
+		got, err := svc.TakeAppointmentByIDAndToken(ctx, apnt.UID, apnt.Token)
 		if err != nil {
 			t.Fatalf("take by id and token: %v", err)
 		}
@@ -85,7 +85,7 @@ func TestAppointmentServiceDBFlows(t *testing.T) {
 	})
 
 	t.Run("listing helpers return data", func(t *testing.T) {
-		appointments, err := svc.FindAppointmentsBy(ctx, user.ID, patient.ID, clinic.ID, "day")
+		appointments, err := svc.FindAppointmentsBy(ctx, user.ID, patient.UID, clinic.UID, "day")
 		if err != nil {
 			t.Fatalf("find appointments: %v", err)
 		}
@@ -136,7 +136,7 @@ func TestAppointmentServiceDBFlows(t *testing.T) {
 			t.Fatalf("create done appointment: %v", err)
 		}
 
-		got, err := svc.TakePatientByIDWithLastDoneAppointment(ctx, user.ID, patient.ID)
+		got, err := svc.TakePatientByUIDWithLastDoneAppointment(ctx, user.ID, patient.UID)
 		if err != nil {
 			t.Fatalf("take patient with done appointment: %v", err)
 		}
@@ -170,7 +170,7 @@ func TestAppointmentServiceDBFlows(t *testing.T) {
 			PatientID:    patient.ID,
 			Duration:     60,
 		}
-		if err := svc.UpdateAppointmentByID(ctx, user.ID, apnt.ID, patch); err != nil {
+		if err := svc.UpdateAppointmentByID(ctx, user.ID, apnt.UID, patch); err != nil {
 			t.Fatalf("update appointment by id: %v", err)
 		}
 
@@ -178,10 +178,10 @@ func TestAppointmentServiceDBFlows(t *testing.T) {
 			t.Fatalf("expected record not found for missing update, got %v", err)
 		}
 
-		if err := svc.DeleteAppointmentByID(ctx, user.ID, apnt.ID); err != nil {
+		if err := svc.DeleteAppointmentByID(ctx, user.ID, apnt.UID); err != nil {
 			t.Fatalf("delete appointment by id: %v", err)
 		}
-		if err := svc.DeleteAppointmentByID(ctx, user.ID, apnt.ID); err != gorm.ErrRecordNotFound {
+		if err := svc.DeleteAppointmentByID(ctx, user.ID, apnt.UID); err != gorm.ErrRecordNotFound {
 			t.Fatalf("expected record not found for repeated delete, got %v", err)
 		}
 	})

--- a/internal/services/appointment/service_validation_test.go
+++ b/internal/services/appointment/service_validation_test.go
@@ -24,40 +24,40 @@ func TestServiceInputValidation(t *testing.T) {
 	})
 
 	t.Run("id-guarded queries fail fast on blank id", func(t *testing.T) {
-		if _, err := svc.TakePatientByID(ctx, "usr_1", "   "); !errors.Is(err, ErrIDRequired) {
+		if _, err := svc.TakePatientByUID(ctx, 1, "   "); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for patient id, got %v", err)
 		}
-		if _, err := svc.TakeClinicByID(ctx, "usr_1", ""); !errors.Is(err, ErrIDRequired) {
+		if _, err := svc.TakeClinicByUID(ctx, 1, ""); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for clinic id, got %v", err)
 		}
-		if _, err := svc.TakeAppointmentByID(ctx, "usr_1", ""); !errors.Is(err, ErrIDRequired) {
+		if _, err := svc.TakeAppointmentByUID(ctx, 1, ""); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for appointment id, got %v", err)
 		}
-		if _, err := svc.TakePatientByIDWithLastDoneAppointment(ctx, "usr_1", ""); !errors.Is(err, ErrIDRequired) {
+		if _, err := svc.TakePatientByUIDWithLastDoneAppointment(ctx, 1, ""); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for patient id with preload, got %v", err)
 		}
 	})
 
 	t.Run("id-guarded mutations fail fast on blank id", func(t *testing.T) {
-		if err := svc.UpdateAppointmentByID(ctx, "usr_1", "", appointmentPatchUpdates{}); !errors.Is(err, ErrIDRequired) {
+		if err := svc.UpdateAppointmentByID(ctx, 1, "", appointmentPatchUpdates{}); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for update, got %v", err)
 		}
-		if err := svc.DeleteAppointmentByID(ctx, "usr_1", ""); !errors.Is(err, ErrIDRequired) {
+		if err := svc.DeleteAppointmentByID(ctx, 1, ""); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for delete, got %v", err)
 		}
-		if err := svc.CompleteAppointmentByID(ctx, "usr_1", "", appointmentCompleteUpdates{}); !errors.Is(err, ErrIDRequired) {
+		if err := svc.CompleteAppointmentByID(ctx, 1, "", appointmentCompleteUpdates{}); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for complete, got %v", err)
 		}
-		if err := svc.CancelAppointmentByID(ctx, "usr_1", "", appointmentCancelUpdates{}); !errors.Is(err, ErrIDRequired) {
+		if err := svc.CancelAppointmentByID(ctx, 1, "", appointmentCancelUpdates{}); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for cancel, got %v", err)
 		}
 	})
 
 	t.Run("status validation catches invalid mutations", func(t *testing.T) {
-		if err := svc.CompleteAppointmentByID(ctx, "usr_1", "apnt_1", appointmentCompleteUpdates{Status: models.AppointmentStatus("invalid")}); err == nil {
+		if err := svc.CompleteAppointmentByID(ctx, 1, "apnt_1", appointmentCompleteUpdates{Status: models.AppointmentStatus("invalid")}); err == nil {
 			t.Fatalf("expected complete invalid status error")
 		}
-		if err := svc.CancelAppointmentByID(ctx, "usr_1", "apnt_1", appointmentCancelUpdates{Status: models.AppointmentStatus("invalid")}); err == nil {
+		if err := svc.CancelAppointmentByID(ctx, 1, "apnt_1", appointmentCancelUpdates{Status: models.AppointmentStatus("invalid")}); err == nil {
 			t.Fatalf("expected cancel invalid status error")
 		}
 		if err := svc.UpdateAppointmentByIDAndToken(ctx, "apnt_1", "tok", []string{"Status"}, appointmentTokenUpdates{Status: models.AppointmentStatus("invalid")}); err == nil {
@@ -66,7 +66,7 @@ func TestServiceInputValidation(t *testing.T) {
 	})
 
 	t.Run("update columns validates required columns", func(t *testing.T) {
-		err := svc.updateAppointmentColumnsByID(ctx, "usr_1", "apnt_1", nil, appointmentPatchUpdates{})
+		err := svc.updateAppointmentColumnsByID(ctx, 1, "apnt_1", nil, appointmentPatchUpdates{})
 		if err == nil {
 			t.Fatalf("expected columns required error")
 		}

--- a/internal/services/appointment/updates.go
+++ b/internal/services/appointment/updates.go
@@ -14,8 +14,8 @@ type appointmentPatchUpdates struct {
 	BookedHour   int
 	BookedMinute int
 	Price        int
-	ClinicID     string
-	PatientID    string
+	ClinicID     uint
+	PatientID    uint
 	Duration     int
 }
 

--- a/internal/services/auth/cookies.go
+++ b/internal/services/auth/cookies.go
@@ -9,7 +9,7 @@ import (
 func (s *service) issueAuthCookie(c fiber.Ctx, user models.User, rememberMe bool) error {
 	validFor := authTokenTTL(rememberMe)
 
-	jwt, err := JWTCreateTokenWithTTL(s.AppEnv(), user.Email, user.ID, validFor, rememberMe)
+	jwt, err := JWTCreateTokenWithTTL(s.AppEnv(), user.Email, user.UID, validFor, rememberMe)
 	if err != nil {
 		return errAuthSessionCreate
 	}

--- a/internal/services/auth/handlers.go
+++ b/internal/services/auth/handlers.go
@@ -174,7 +174,7 @@ func (s *service) HandleSignupConfirmEmail(c fiber.Ctx) error {
 	}
 
 	user, err := gorm.G[models.User](s.DB.GormDB()).
-		Select("id, email, confirm_email_token").
+		Select("uid, email, confirm_email_token").
 		Where("confirm_email_token = ? AND confirm_email_expires_at > ?", token, time.Now()).
 		Take(c.Context())
 	if err != nil {
@@ -189,7 +189,7 @@ func (s *service) HandleSignupConfirmEmail(c fiber.Ctx) error {
 		return s.respondWithRedirect(c, "/signin", "Email confirmed, you should be able to signin now")
 	}
 
-	jwt, err := JWTCreateToken(s.AppEnv(), user.Email, user.ID)
+	jwt, err := JWTCreateToken(s.AppEnv(), user.Email, user.UID)
 	if err != nil {
 		return s.respondWithRedirect(c, "/signin", "Email confirmed, you should be able to signin now")
 	}

--- a/internal/services/auth/handlers_test.go
+++ b/internal/services/auth/handlers_test.go
@@ -28,7 +28,7 @@ func TestAuthHandlersSigninAndAPI(t *testing.T) {
 
 		app := fiber.New()
 		app.Get("/signin", func(c fiber.Ctx) error {
-			c.Locals("current_user", models.User{ID: "user_1"})
+			c.Locals("current_user", models.User{UID: "user_1"})
 			return svc.HandleSigninPage(c)
 		})
 
@@ -370,7 +370,7 @@ func TestAuthHandlersLogoutAndSessionEndpoints(t *testing.T) {
 		svc := newAuthServiceForTests(t)
 		app := fiber.New()
 		app.Get("/api/auth/protected", func(c fiber.Ctx) error {
-			c.Locals("current_user", models.User{ID: "user_123", Email: "u@example.com"})
+			c.Locals("current_user", models.User{UID: "user_123", Email: "u@example.com"})
 			return svc.HandleShowUser(c)
 		})
 
@@ -427,7 +427,7 @@ func TestAuthHandlersSignupPaths(t *testing.T) {
 		svc := newAuthServiceForTests(t)
 		app := fiber.New()
 		app.Get("/signup", func(c fiber.Ctx) error {
-			c.Locals("current_user", models.User{ID: "user_1"})
+			c.Locals("current_user", models.User{UID: "user_1"})
 			return svc.HandleSignupPage(c)
 		})
 

--- a/internal/services/auth/local_strategy.go
+++ b/internal/services/auth/local_strategy.go
@@ -25,7 +25,8 @@ const (
 
 type AuthSnapshot struct {
 	Token          string          // t
-	UserID         string          // uid
+	UserID         uint            // id
+	UserUID        string          // uid
 	UserEmail      string          // em
 	UserRole       models.UserRole // rl
 	UserName       string          // nm
@@ -141,13 +142,14 @@ func (ls LocalStrategy) currentUserFromSession(c fiber.Ctx, token string) (model
 }
 
 func (ls LocalStrategy) saveCurrentUserToSession(c fiber.Ctx, token string, user models.User) {
-	if token == "" || user.UID == "" {
+	if token == "" || user.ID == 0 || user.UID == "" {
 		return
 	}
 
 	ls.writeAuthSnapshot(c, AuthSnapshot{
 		Token:          tokenDigest(token),
-		UserID:         user.UID,
+		UserID:         user.ID,
+		UserUID:        user.UID,
 		UserEmail:      user.Email,
 		UserRole:       user.Role,
 		UserName:       user.Name,
@@ -177,7 +179,8 @@ func (ls LocalStrategy) writeAuthSnapshot(c fiber.Ctx, snapshot AuthSnapshot) {
 func EncodeAuthSnapshot(sa AuthSnapshot) string {
 	v := url.Values{}
 	v.Set("t", sa.Token)
-	v.Set("uid", sa.UserID)
+	v.Set("id", strconv.FormatUint(uint64(sa.UserID), 10))
+	v.Set("uid", sa.UserUID)
 	v.Set("em", sa.UserEmail)
 	v.Set("rl", string(sa.UserRole))
 	v.Set("nm", sa.UserName)
@@ -204,14 +207,22 @@ func DecodeAuthSnapshot(raw string) (AuthSnapshot, bool) {
 
 	sa := AuthSnapshot{
 		Token:          v.Get("t"),
-		UserID:         v.Get("uid"),
+		UserID:         0,
+		UserUID:        v.Get("uid"),
 		UserEmail:      v.Get("em"),
 		UserRole:       models.UserRole(v.Get("rl")),
 		UserName:       v.Get("nm"),
 		UserProfilePic: v.Get("pp"),
 		CachedAtUnix:   cachedAtUnix,
 	}
-	if sa.Token == "" || sa.UserID == "" {
+
+	userID, err := strconv.ParseUint(v.Get("id"), 10, 64)
+	if err != nil {
+		return AuthSnapshot{}, false
+	}
+	sa.UserID = uint(userID)
+
+	if sa.Token == "" || sa.UserUID == "" || sa.UserID == 0 {
 		return AuthSnapshot{}, false
 	}
 
@@ -219,7 +230,7 @@ func DecodeAuthSnapshot(raw string) (AuthSnapshot, bool) {
 }
 
 func (sa AuthSnapshot) isValidForToken(token string, now time.Time) bool {
-	if token == "" || sa.Token == "" || sa.UserID == "" {
+	if token == "" || sa.Token == "" || sa.UserUID == "" || sa.UserID == 0 {
 		return false
 	}
 	if sa.Token != token {
@@ -234,7 +245,8 @@ func (sa AuthSnapshot) isValidForToken(token string, now time.Time) bool {
 
 func (sa AuthSnapshot) toUser() models.User {
 	return models.User{
-		UID:        sa.UserID,
+		ID:         sa.UserID,
+		UID:        sa.UserUID,
 		Email:      sa.UserEmail,
 		Role:       sa.UserRole,
 		Name:       sa.UserName,

--- a/internal/services/auth/local_strategy.go
+++ b/internal/services/auth/local_strategy.go
@@ -77,7 +77,7 @@ func (ls LocalStrategy) Metadata() AuthenticatorMeta {
 }
 
 func (ls LocalStrategy) FindUserById(ctx context.Context, uid string) (models.User, error) {
-	return gorm.G[models.User](ls.resource.GormDB()).Where("id = ?", uid).Take(ctx)
+	return gorm.G[models.User](ls.resource.GormDB()).Where("uid = ?", uid).Take(ctx)
 }
 
 func (ls LocalStrategy) authenticateWithJWT(c fiber.Ctx, token string) (models.User, error) {
@@ -141,13 +141,13 @@ func (ls LocalStrategy) currentUserFromSession(c fiber.Ctx, token string) (model
 }
 
 func (ls LocalStrategy) saveCurrentUserToSession(c fiber.Ctx, token string, user models.User) {
-	if token == "" || user.ID == "" {
+	if token == "" || user.UID == "" {
 		return
 	}
 
 	ls.writeAuthSnapshot(c, AuthSnapshot{
 		Token:          tokenDigest(token),
-		UserID:         user.ID,
+		UserID:         user.UID,
 		UserEmail:      user.Email,
 		UserRole:       user.Role,
 		UserName:       user.Name,
@@ -234,7 +234,7 @@ func (sa AuthSnapshot) isValidForToken(token string, now time.Time) bool {
 
 func (sa AuthSnapshot) toUser() models.User {
 	return models.User{
-		ID:         sa.UserID,
+		UID:        sa.UserID,
 		Email:      sa.UserEmail,
 		Role:       sa.UserRole,
 		Name:       sa.UserName,

--- a/internal/services/auth/local_strategy_runtime_test.go
+++ b/internal/services/auth/local_strategy_runtime_test.go
@@ -90,13 +90,13 @@ func TestLocalStrategyAuthenticateSuccessAndRefresh(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected authenticate success, got %v", err)
 		}
-		if authed.ID != user.ID {
-			t.Fatalf("expected authenticated user id %q, got %q", user.ID, authed.ID)
+		if authed.UID != user.UID {
+			t.Fatalf("expected authenticated user uid %q, got %q", user.UID, authed.UID)
 		}
 		return c.SendStatus(fiber.StatusNoContent)
 	})
 
-	soonExpiring, err := JWTCreateTokenWithTTL(svc.Env, user.Email, user.ID, 30*time.Minute, false)
+	soonExpiring, err := JWTCreateTokenWithTTL(svc.Env, user.Email, user.UID, 30*time.Minute, false)
 	if err != nil {
 		t.Fatalf("create token: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestLocalStrategyAuthenticateSessionHydration(t *testing.T) {
 	strategy := NewLocalStrategy(svc)
 	user := seedAuthUserWithOptions(t, svc, authUserSeedOptions{Email: "session-cache@example.com", Password: "Password1!"})
 
-	token, err := JWTCreateTokenWithTTL(svc.Env, user.Email, user.ID, 2*time.Hour, false)
+	token, err := JWTCreateTokenWithTTL(svc.Env, user.Email, user.UID, 2*time.Hour, false)
 	if err != nil {
 		t.Fatalf("create token: %v", err)
 	}
@@ -129,8 +129,8 @@ func TestLocalStrategyAuthenticateSessionHydration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected authenticate success, got %v", err)
 		}
-		if authed.ID != user.ID {
-			t.Fatalf("expected authenticated user id %q, got %q", user.ID, authed.ID)
+		if authed.UID != user.UID {
+			t.Fatalf("expected authenticated user uid %q, got %q", user.UID, authed.UID)
 		}
 		return c.SendStatus(fiber.StatusNoContent)
 	})
@@ -164,7 +164,7 @@ func TestLocalStrategyAuthenticateSessionHydrationTokenMismatch(t *testing.T) {
 	strategy := NewLocalStrategy(svc)
 	user := seedAuthUserWithOptions(t, svc, authUserSeedOptions{Email: "session-mismatch@example.com", Password: "Password1!"})
 
-	validToken, err := JWTCreateTokenWithTTL(svc.Env, user.Email, user.ID, 2*time.Hour, false)
+	validToken, err := JWTCreateTokenWithTTL(svc.Env, user.Email, user.UID, 2*time.Hour, false)
 	if err != nil {
 		t.Fatalf("create token: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestRuntimeAuthenticateAndTakeUserByExtID(t *testing.T) {
 		svc := newAuthServiceForTests(t)
 		user := seedAuthUserWithOptions(t, svc, authUserSeedOptions{Email: "runtime@example.com", Password: "Password1!"})
 
-		token, err := JWTCreateTokenWithTTL(svc.Env, user.Email, user.ID, time.Hour, false)
+		token, err := JWTCreateTokenWithTTL(svc.Env, user.Email, user.UID, time.Hour, false)
 		if err != nil {
 			t.Fatalf("create token: %v", err)
 		}
@@ -219,8 +219,8 @@ func TestRuntimeAuthenticateAndTakeUserByExtID(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected runtime authenticate success, got %v", err)
 			}
-			if authed.ID != user.ID {
-				t.Fatalf("expected %q, got %q", user.ID, authed.ID)
+			if authed.UID != user.UID {
+				t.Fatalf("expected %q, got %q", user.UID, authed.UID)
 			}
 			return c.SendStatus(fiber.StatusNoContent)
 		})
@@ -244,8 +244,8 @@ func TestRuntimeAuthenticateAndTakeUserByExtID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected TakeUserByExtID success, got %v", err)
 		}
-		if got.ID != u.ID {
-			t.Fatalf("expected user id %q, got %q", u.ID, got.ID)
+		if got.UID != u.UID {
+			t.Fatalf("expected user uid %q, got %q", u.UID, got.UID)
 		}
 	})
 

--- a/internal/services/auth/local_strategy_runtime_test.go
+++ b/internal/services/auth/local_strategy_runtime_test.go
@@ -93,6 +93,9 @@ func TestLocalStrategyAuthenticateSuccessAndRefresh(t *testing.T) {
 		if authed.UID != user.UID {
 			t.Fatalf("expected authenticated user uid %q, got %q", user.UID, authed.UID)
 		}
+		if authed.ID != user.ID {
+			t.Fatalf("expected authenticated user id %d, got %d", user.ID, authed.ID)
+		}
 		return c.SendStatus(fiber.StatusNoContent)
 	})
 
@@ -131,6 +134,9 @@ func TestLocalStrategyAuthenticateSessionHydration(t *testing.T) {
 		}
 		if authed.UID != user.UID {
 			t.Fatalf("expected authenticated user uid %q, got %q", user.UID, authed.UID)
+		}
+		if authed.ID != user.ID {
+			t.Fatalf("expected authenticated user id %d, got %d", user.ID, authed.ID)
 		}
 		return c.SendStatus(fiber.StatusNoContent)
 	})
@@ -222,6 +228,9 @@ func TestRuntimeAuthenticateAndTakeUserByExtID(t *testing.T) {
 			if authed.UID != user.UID {
 				t.Fatalf("expected %q, got %q", user.UID, authed.UID)
 			}
+			if authed.ID != user.ID {
+				t.Fatalf("expected %d, got %d", user.ID, authed.ID)
+			}
 			return c.SendStatus(fiber.StatusNoContent)
 		})
 
@@ -262,7 +271,8 @@ func TestDecodeAuthSnapshot(t *testing.T) {
 	t.Run("roundtrip encode decode", func(t *testing.T) {
 		in := AuthSnapshot{
 			Token:          "jwt-token",
-			UserID:         "user_123",
+			UserID:         42,
+			UserUID:        "user_123",
 			UserEmail:      "u@example.com",
 			UserRole:       models.UserRoleAdmin,
 			UserName:       "Ada",
@@ -274,25 +284,30 @@ func TestDecodeAuthSnapshot(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected decode success")
 		}
-		if out.Token != in.Token || out.UserID != in.UserID || out.UserEmail != in.UserEmail {
+		if out.Token != in.Token || out.UserID != in.UserID || out.UserUID != in.UserUID || out.UserEmail != in.UserEmail {
 			t.Fatalf("decoded auth mismatch: got %+v", out)
 		}
 	})
 
 	t.Run("fails for malformed cached timestamp", func(t *testing.T) {
-		_, ok := DecodeAuthSnapshot("t=a&uid=u1&cat=not-a-number")
+		_, ok := DecodeAuthSnapshot("t=a&id=1&uid=u1&cat=not-a-number")
 		if ok {
 			t.Fatalf("expected decode failure")
 		}
 	})
 
 	t.Run("fails when required fields missing", func(t *testing.T) {
-		_, ok := DecodeAuthSnapshot("uid=u1&cat=123")
+		_, ok := DecodeAuthSnapshot("id=1&uid=u1&cat=123")
 		if ok {
 			t.Fatalf("expected decode failure when token is missing")
 		}
 
-		_, ok = DecodeAuthSnapshot("t=a&cat=123")
+		_, ok = DecodeAuthSnapshot("t=a&id=1&cat=123")
+		if ok {
+			t.Fatalf("expected decode failure when user id is missing")
+		}
+
+		_, ok = DecodeAuthSnapshot("t=a&uid=u1&cat=123")
 		if ok {
 			t.Fatalf("expected decode failure when user id is missing")
 		}
@@ -324,14 +339,14 @@ func TestAuthSnapshotTTLBoundary(t *testing.T) {
 	token := tokenDigest("header.payload.signature")
 
 	t.Run("accepts snapshot at ttl boundary", func(t *testing.T) {
-		s := AuthSnapshot{Token: token, UserID: "u1", CachedAtUnix: now.Add(-authSessionHydrationTTL).Unix()}
+		s := AuthSnapshot{Token: token, UserID: 1, UserUID: "u1", CachedAtUnix: now.Add(-authSessionHydrationTTL).Unix()}
 		if !s.isValidForToken(token, now) {
 			t.Fatalf("expected snapshot valid at ttl boundary")
 		}
 	})
 
 	t.Run("rejects snapshot older than ttl", func(t *testing.T) {
-		s := AuthSnapshot{Token: token, UserID: "u1", CachedAtUnix: now.Add(-authSessionHydrationTTL - time.Second).Unix()}
+		s := AuthSnapshot{Token: token, UserID: 1, UserUID: "u1", CachedAtUnix: now.Add(-authSessionHydrationTTL - time.Second).Unix()}
 		if s.isValidForToken(token, now) {
 			t.Fatalf("expected snapshot invalid past ttl")
 		}

--- a/internal/services/auth/runtime_cookie_test.go
+++ b/internal/services/auth/runtime_cookie_test.go
@@ -56,7 +56,7 @@ func TestIssueAuthCookie(t *testing.T) {
 
 		app := fiber.New()
 		app.Get("/", func(c fiber.Ctx) error {
-			if err := svc.issueAuthCookie(c, models.User{ID: "user_1", Email: "u@example.com"}, true); err != nil {
+			if err := svc.issueAuthCookie(c, models.User{UID: "user_1", Email: "u@example.com"}, true); err != nil {
 				return err
 			}
 			return c.SendStatus(fiber.StatusNoContent)
@@ -79,7 +79,7 @@ func TestIssueAuthCookie(t *testing.T) {
 
 		app := fiber.New()
 		app.Get("/", func(c fiber.Ctx) error {
-			err := svc.issueAuthCookie(c, models.User{ID: "user_1", Email: "u@example.com"}, false)
+			err := svc.issueAuthCookie(c, models.User{UID: "user_1", Email: "u@example.com"}, false)
 			if !errors.Is(err, errAuthSessionCreate) {
 				t.Fatalf("expected errAuthSessionCreate, got %v", err)
 			}

--- a/internal/services/auth/service.go
+++ b/internal/services/auth/service.go
@@ -93,7 +93,7 @@ func (s *service) signupIsEmailValid(ctx context.Context, email string) error {
 	}
 
 	user, err := gorm.G[models.User](s.DB.GormDB()).Where("email = ?", email).Take(ctx)
-	if err == nil && user.ID != "" {
+	if err == nil && user.ID != 0 {
 		return errors.New("email already exists, try login instead")
 	}
 
@@ -122,7 +122,7 @@ func (s *service) userPendingConfirmation(ctx context.Context, email string) err
 		Select("ID, Email, ConfirmEmailToken").
 		Where("email = ? AND confirm_email_token IS NOT null AND confirm_email_token != ''", email).
 		Take(ctx)
-	if err == nil && user.ID != "" { // If a row/record exists it means confirmation is pending and we should re-send
+	if err == nil && user.ID != 0 { // If a row/record exists it means confirmation is pending and we should re-send
 		return errors.New("user pending confirmation")
 	}
 
@@ -240,7 +240,7 @@ func (s *service) saveLogtoUser(ctx context.Context, logtoUser LogtoUser) error 
 		return fmt.Errorf("failed to load user from logto claims, GORM error: %w", err)
 	}
 
-	userExists := user.ID != ""
+	userExists := user.ID != 0
 	extIDMatchesUID := user.ExtID == logtoUser.UID
 	if userExists && extIDMatchesUID {
 		return nil

--- a/internal/services/clinic/handlers.go
+++ b/internal/services/clinic/handlers.go
@@ -77,7 +77,7 @@ func (s *service) HandleClinicsCreate(c fiber.Ctx) error {
 	if err != nil {
 		return s.respondWithRedirect(c, "/clinics/new?toast=Invalid clinic input&level=error", fiber.StatusBadRequest)
 	}
-	clinic := input.toClinic("", cu.ID, price)
+	clinic := input.toClinic(0, "", cu.ID, price)
 
 	err = s.CreateClinic(c.Context(), &clinic)
 	if err != nil {
@@ -115,7 +115,7 @@ func (s *service) HandleClinicsUpdate(c fiber.Ctx) error {
 		return s.respondWithRedirect(c, "/clinics/"+clinicID+"?toast=Invalid clinic input&level=error", fiber.StatusBadRequest)
 	}
 
-	clinic = input.toClinic(clinic.ID, clinic.UserID, amount.StrToAmount(c.FormValue("price", "")))
+	clinic = input.toClinic(clinic.ID, clinic.UID, clinic.UserID, amount.StrToAmount(c.FormValue("price", "")))
 
 	s.attachClinicProfilePicBestEffort(c, cu.ID, &clinic)
 
@@ -225,15 +225,15 @@ func (s *service) respondWithRedirect(c fiber.Ctx, redirectPath string, htmxStat
 
 func (s *service) respondWithClinicPage(c fiber.Ctx, clinic models.Clinic) error {
 	if s.NotHTMX(c) {
-		return s.Redirect(c, "/clinics/"+clinic.ID)
+		return s.Redirect(c, "/clinics/"+clinic.UID)
 	}
 
-	c.Set("HX-Push-Url", "/clinics/"+clinic.ID)
+	c.Set("HX-Push-Url", "/clinics/"+clinic.UID)
 	vc, _ := view.NewCtx(c)
 	return view.Render(c, view.ClinicPage(vc, clinic))
 }
 
-func (s *service) attachClinicProfilePicBestEffort(c fiber.Ctx, userID string, clinic *models.Clinic) {
+func (s *service) attachClinicProfilePicBestEffort(c fiber.Ctx, userID uint, clinic *models.Clinic) {
 	path, picErr := SaveProfilePicToDisk(c, *clinic)
 	if errors.Is(picErr, ErrProfilePicNotProvided) {
 		return
@@ -245,7 +245,7 @@ func (s *service) attachClinicProfilePicBestEffort(c fiber.Ctx, userID string, c
 
 	clinic.ProfilePic = path
 	profilePicUpdate := models.Clinic{ProfilePic: path}
-	err := s.UpdateClinicByID(c.Context(), userID, clinic.ID, profilePicUpdate)
+	err := s.UpdateClinicByID(c.Context(), userID, clinic.UID, profilePicUpdate)
 	if err != nil {
 		log.Error(err)
 	}

--- a/internal/services/clinic/handlers_branches_test.go
+++ b/internal/services/clinic/handlers_branches_test.go
@@ -79,7 +79,7 @@ func TestClinicHandlersHappyPaths(t *testing.T) {
 		return svc.HandleClinicsShowPage(c)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/clinics/"+clinic.ID, nil))
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/clinics/"+clinic.UID, nil))
 	if err != nil || resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("show existing clinic expected 200, got status=%d err=%v", resp.StatusCode, err)
 	}

--- a/internal/services/clinic/inputs.go
+++ b/internal/services/clinic/inputs.go
@@ -21,9 +21,10 @@ type clinicUpsertInput struct {
 	Facebook  string `form:"facebook"`
 }
 
-func (in clinicUpsertInput) toClinic(id, userID string, price int) models.Clinic {
+func (in clinicUpsertInput) toClinic(id uint, uid string, userID uint, price int) models.Clinic {
 	return models.Clinic{
 		ID:     id,
+		UID:    uid,
 		UserID: userID,
 		Price:  price,
 		Name:   in.Name,

--- a/internal/services/clinic/profile_pic.go
+++ b/internal/services/clinic/profile_pic.go
@@ -18,8 +18,8 @@ func SaveProfilePicToDisk(c fiber.Ctx, clinic models.Clinic) (string, error) {
 		return "", ErrProfilePicNotProvided
 	}
 
-	if clinic.ID == "" {
-		return "", errors.New("can't save profile pic without clinic.ID")
+	if clinic.UID == "" {
+		return "", errors.New("can't save profile pic without clinic.UID")
 	}
 
 	filename := strings.TrimSpace(profilePic.Filename)
@@ -29,7 +29,7 @@ func SaveProfilePicToDisk(c fiber.Ctx, clinic models.Clinic) (string, error) {
 		return "", errors.New("invalid profile picture filename")
 	}
 
-	profilePath := "/public/assets/profile_pics/" + clinic.ID + "_" + filename
+	profilePath := "/public/assets/profile_pics/" + clinic.UID + "_" + filename
 	err = c.SaveFile(profilePic, "."+profilePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to save profilePic to disk: %w", err)

--- a/internal/services/clinic/profile_pic_test.go
+++ b/internal/services/clinic/profile_pic_test.go
@@ -15,7 +15,7 @@ import (
 func TestSaveProfilePicToDisk(t *testing.T) {
 	t.Run("missing file returns ErrProfilePicNotProvided", func(t *testing.T) {
 		runClinicCtx(t, "", nil, func(c fiber.Ctx) {
-			_, err := SaveProfilePicToDisk(c, models.Clinic{ID: "cln_1"})
+			_, err := SaveProfilePicToDisk(c, models.Clinic{UID: "cln_1"})
 			if err != ErrProfilePicNotProvided {
 				t.Fatalf("expected ErrProfilePicNotProvided, got %v", err)
 			}
@@ -33,7 +33,7 @@ func TestSaveProfilePicToDisk(t *testing.T) {
 
 	t.Run("rejects invalid sanitized filename", func(t *testing.T) {
 		runClinicCtx(t, "..", []byte("img"), func(c fiber.Ctx) {
-			_, err := SaveProfilePicToDisk(c, models.Clinic{ID: "cln_1"})
+			_, err := SaveProfilePicToDisk(c, models.Clinic{UID: "cln_1"})
 			if err == nil {
 				t.Fatalf("expected invalid filename error")
 			}

--- a/internal/services/clinic/service.go
+++ b/internal/services/clinic/service.go
@@ -26,14 +26,14 @@ func NewService(s *server.Server) (service, error) {
 	}, nil
 }
 
-func (s service) TakeClinicByID(ctx context.Context, userID, clinicID string) (models.Clinic, error) {
+func (s service) TakeClinicByID(ctx context.Context, userID uint, clinicID string) (models.Clinic, error) {
 	clinicID = strings.TrimSpace(clinicID)
 	if clinicID == "" {
 		return models.Clinic{}, ErrIDRequired
 	}
 
 	clinic, err := gorm.G[models.Clinic](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", clinicID, userID).
+		Where("uid = ? AND user_id = ?", clinicID, userID).
 		Take(ctx)
 	if err != nil {
 		return models.Clinic{}, err
@@ -68,7 +68,7 @@ func (s service) CreateClinic(ctx context.Context, clinic *models.Clinic) error 
 	return gorm.G[models.Clinic](s.DB.GormDB()).Create(ctx, clinic)
 }
 
-func (s service) UpdateClinicByID(ctx context.Context, userID, clinicID string, clinic models.Clinic) error {
+func (s service) UpdateClinicByID(ctx context.Context, userID uint, clinicID string, clinic models.Clinic) error {
 	clinicID = strings.TrimSpace(clinicID)
 	if clinicID == "" {
 		return ErrIDRequired
@@ -80,7 +80,7 @@ func (s service) UpdateClinicByID(ctx context.Context, userID, clinicID string, 
 	}
 
 	rowsAffected, err := gorm.G[models.Clinic](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", clinicID, userID).
+		Where("uid = ? AND user_id = ?", clinicID, userID).
 		Updates(ctx, clinic)
 	if err != nil {
 		return err
@@ -100,14 +100,14 @@ func (s service) UpdateClinicByID(ctx context.Context, userID, clinicID string, 
 	return nil
 }
 
-func (s service) DeleteClinicByID(ctx context.Context, userID, clinicID string) error {
+func (s service) DeleteClinicByID(ctx context.Context, userID uint, clinicID string) error {
 	clinicID = strings.TrimSpace(clinicID)
 	if clinicID == "" {
 		return ErrIDRequired
 	}
 
 	rowsAffected, err := gorm.G[models.Clinic](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", clinicID, userID).
+		Where("uid = ? AND user_id = ?", clinicID, userID).
 		Delete(ctx)
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func (s service) DeleteClinicByID(ctx context.Context, userID, clinicID string) 
 	return nil
 }
 
-func (s service) clinicExistsByID(ctx context.Context, userID, clinicID string) (bool, error) {
+func (s service) clinicExistsByID(ctx context.Context, userID uint, clinicID string) (bool, error) {
 	clinicID = strings.TrimSpace(clinicID)
 	if clinicID == "" {
 		return false, ErrIDRequired
@@ -128,7 +128,7 @@ func (s service) clinicExistsByID(ctx context.Context, userID, clinicID string) 
 	var count int64
 	err := s.DB.WithContext(ctx).
 		Model(&models.Clinic{}).
-		Where("id = ? AND user_id = ?", clinicID, userID).
+		Where("uid = ? AND user_id = ?", clinicID, userID).
 		Count(&count).Error
 	if err != nil {
 		return false, err

--- a/internal/services/clinic/service_db_test.go
+++ b/internal/services/clinic/service_db_test.go
@@ -25,12 +25,12 @@ func TestClinicServiceDBFlows(t *testing.T) {
 	}
 
 	t.Run("take and search clinics", func(t *testing.T) {
-		got, err := svc.TakeClinicByID(ctx, user.ID, base.ID)
+		got, err := svc.TakeClinicByID(ctx, user.ID, base.UID)
 		if err != nil {
 			t.Fatalf("take clinic by id: %v", err)
 		}
-		if got.ID != base.ID {
-			t.Fatalf("expected clinic id %q, got %q", base.ID, got.ID)
+		if got.UID != base.UID {
+			t.Fatalf("expected clinic uid %q, got %q", base.UID, got.UID)
 		}
 
 		recent, err := svc.FindClinicsBySearchTerm(ctx, user, "")
@@ -49,11 +49,11 @@ func TestClinicServiceDBFlows(t *testing.T) {
 
 	t.Run("update clinic and existence branches", func(t *testing.T) {
 		upd := models.Clinic{Name: "  Beta Clinic  ", Email: "  BETA@EXAMPLE.COM  ", Phone: " 999 "}
-		if err := svc.UpdateClinicByID(ctx, user.ID, base.ID, upd); err != nil {
+		if err := svc.UpdateClinicByID(ctx, user.ID, base.UID, upd); err != nil {
 			t.Fatalf("update clinic by id: %v", err)
 		}
 
-		got, err := svc.TakeClinicByID(ctx, user.ID, base.ID)
+		got, err := svc.TakeClinicByID(ctx, user.ID, base.UID)
 		if err != nil {
 			t.Fatalf("reload clinic after update: %v", err)
 		}
@@ -65,11 +65,11 @@ func TestClinicServiceDBFlows(t *testing.T) {
 			t.Fatalf("expected not found on missing update, got %v", err)
 		}
 
-		if err := svc.UpdateClinicByID(ctx, user.ID, base.ID, models.Clinic{Email: strings.Repeat("e", 255)}); err == nil {
+		if err := svc.UpdateClinicByID(ctx, user.ID, base.UID, models.Clinic{Email: strings.Repeat("e", 255)}); err == nil {
 			t.Fatalf("expected normalization error on too long email")
 		}
 
-		exists, err := svc.clinicExistsByID(ctx, user.ID, base.ID)
+		exists, err := svc.clinicExistsByID(ctx, user.ID, base.UID)
 		if err != nil {
 			t.Fatalf("clinic exists check: %v", err)
 		}
@@ -87,10 +87,10 @@ func TestClinicServiceDBFlows(t *testing.T) {
 	})
 
 	t.Run("delete clinic by id", func(t *testing.T) {
-		if err := svc.DeleteClinicByID(ctx, user.ID, base.ID); err != nil {
+		if err := svc.DeleteClinicByID(ctx, user.ID, base.UID); err != nil {
 			t.Fatalf("delete clinic by id: %v", err)
 		}
-		if err := svc.DeleteClinicByID(ctx, user.ID, base.ID); err != gorm.ErrRecordNotFound {
+		if err := svc.DeleteClinicByID(ctx, user.ID, base.UID); err != gorm.ErrRecordNotFound {
 			t.Fatalf("expected not found on repeated delete, got %v", err)
 		}
 	})

--- a/internal/services/clinic/service_helpers_test.go
+++ b/internal/services/clinic/service_helpers_test.go
@@ -16,16 +16,16 @@ func TestServiceIDGuards(t *testing.T) {
 	svc := service{}
 	ctx := context.Background()
 
-	if _, err := svc.TakeClinicByID(ctx, "usr_1", ""); err != ErrIDRequired {
+	if _, err := svc.TakeClinicByID(ctx, 1, ""); err != ErrIDRequired {
 		t.Fatalf("expected ErrIDRequired from TakeClinicByID, got %v", err)
 	}
-	if err := svc.UpdateClinicByID(ctx, "usr_1", "", models.Clinic{}); err != ErrIDRequired {
+	if err := svc.UpdateClinicByID(ctx, 1, "", models.Clinic{}); err != ErrIDRequired {
 		t.Fatalf("expected ErrIDRequired from UpdateClinicByID, got %v", err)
 	}
-	if err := svc.DeleteClinicByID(ctx, "usr_1", ""); err != ErrIDRequired {
+	if err := svc.DeleteClinicByID(ctx, 1, ""); err != ErrIDRequired {
 		t.Fatalf("expected ErrIDRequired from DeleteClinicByID, got %v", err)
 	}
-	if _, err := svc.clinicExistsByID(ctx, "usr_1", ""); err != ErrIDRequired {
+	if _, err := svc.clinicExistsByID(ctx, 1, ""); err != ErrIDRequired {
 		t.Fatalf("expected ErrIDRequired from clinicExistsByID, got %v", err)
 	}
 }
@@ -51,7 +51,7 @@ func TestRespondHelpers(t *testing.T) {
 	t.Run("respondWithClinicPage non-htmx", func(t *testing.T) {
 		app := fiber.New()
 		app.Get("/clinics", func(c fiber.Ctx) error {
-			return svc.respondWithClinicPage(c, models.Clinic{ID: "cln_1"})
+			return svc.respondWithClinicPage(c, models.Clinic{UID: "cln_1"})
 		})
 
 		resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/clinics", nil))

--- a/internal/services/clinic/service_inputs_test.go
+++ b/internal/services/clinic/service_inputs_test.go
@@ -20,8 +20,8 @@ func TestClinicUpsertInputToClinic(t *testing.T) {
 		Facebook:       "fb",
 	}
 
-	clinic := in.toClinic("cln_1", "usr_1", 250)
-	if clinic.ID != "cln_1" || clinic.UserID != "usr_1" || clinic.Price != 250 {
+	clinic := in.toClinic(1, "cln_1", 2, 250)
+	if clinic.ID != 1 || clinic.UID != "cln_1" || clinic.UserID != 2 || clinic.Price != 250 {
 		t.Fatalf("unexpected identifiers mapping: %#v", clinic)
 	}
 	if clinic.Name != in.Name || clinic.Email != in.Email || clinic.Phone != in.Phone {

--- a/internal/services/dashboard/service.go
+++ b/internal/services/dashboard/service.go
@@ -31,9 +31,9 @@ func NewService(s *server.Server) (service, error) {
 	}, nil
 }
 
-func (s service) FavoriteClinic(c fiber.Ctx, uid string) (models.Clinic, error) {
+func (s service) FavoriteClinic(c fiber.Ctx, userID uint) (models.Clinic, error) {
 	clinics, err := gorm.G[models.Clinic](s.DB.GormDB()).
-		Where("user_id = ?", uid).
+		Where("user_id = ?", userID).
 		Order("favorite DESC, created_at").
 		Limit(1).
 		Find(c.Context())
@@ -52,7 +52,7 @@ func (s service) CalcDashboardStats(ctx context.Context, cu models.User) view.Da
 	ctx, span := s.Trace(ctx, "dashboard/services.CalcDashboardStats")
 	defer span.End()
 
-	cacheKey := cu.ID + ".dashboard.stats"
+	cacheKey := cu.UID + ".dashboard.stats"
 	if stats, ok := s.ReadStatsCache(cacheKey); ok {
 		return stats
 	}
@@ -64,7 +64,7 @@ func (s service) CalcDashboardStats(ctx context.Context, cu models.User) view.Da
 		Appointments: apptStats,
 	}
 
-	s.WriteStatsCache(cacheKey, stats)
+	_ = s.WriteStatsCache(cacheKey, stats)
 
 	return stats
 }

--- a/internal/services/patient/handlers.go
+++ b/internal/services/patient/handlers.go
@@ -94,7 +94,7 @@ func (s *service) HandleCreatePatient(c fiber.Ctx) error {
 		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
 	}
 
-	patient := input.toPatient("", cu.ID)
+	patient := input.toPatient(0, "", cu.ID)
 
 	patient.Sanitize()
 
@@ -112,17 +112,17 @@ func (s *service) HandleCreatePatient(c fiber.Ctx) error {
 	} else {
 		patient.ProfilePic = path
 		profilePicUpdate := models.Patient{ProfilePic: path}
-		err = s.UpdatePatientByID(c.Context(), cu.ID, patient.ID, profilePicUpdate)
+		err = s.UpdatePatientByID(c.Context(), cu.ID, patient.UID, profilePicUpdate)
 		if err != nil {
 			log.Error(err)
 		}
 	}
 
 	if s.NotHTMX(c) {
-		return s.Redirect(c, "/patients/"+patient.ID)
+		return s.Redirect(c, "/patients/"+patient.UID)
 	}
 
-	c.Set("HX-Push-Url", "/patients/"+patient.ID)
+	c.Set("HX-Push-Url", "/patients/"+patient.UID)
 	theme := s.SessionUITheme(c)
 	vc, _ := view.NewCtx(
 		c,
@@ -164,7 +164,17 @@ func (s *service) HandleUpdatePatient(c fiber.Ctx) error {
 		return s.respondWithRedirect(c, redirectPath, fiber.StatusBadRequest)
 	}
 
-	patient := input.toPatient(patientID, cu.ID)
+	existingPatient, findErr := s.TakePatientByID(c.Context(), cu.ID, patientID)
+	if errors.Is(findErr, gorm.ErrRecordNotFound) {
+		redirectPath := "/patients?toast=Patient does not exist&level=warning"
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusNotFound)
+	}
+	if findErr != nil {
+		redirectPath := "/patients?toast=Failed to load patient&level=error"
+		return s.respondWithRedirect(c, redirectPath, fiber.StatusInternalServerError)
+	}
+
+	patient := input.toPatient(existingPatient.ID, existingPatient.UID, cu.ID)
 
 	patient.Sanitize()
 
@@ -243,7 +253,7 @@ func (s *service) HandleRemovePic(c fiber.Ctx) error {
 	}
 
 	if s.NotHTMX(c) {
-		return s.Redirect(c, "/patients/"+patient.ID)
+		return s.Redirect(c, "/patients/"+patient.UID)
 	}
 
 	theme := s.SessionUITheme(c)

--- a/internal/services/patient/handlers_flow_test.go
+++ b/internal/services/patient/handlers_flow_test.go
@@ -63,7 +63,7 @@ func TestPatientHandlersFlows(t *testing.T) {
 		t.Fatalf("index page expected 200, got status=%d err=%v", resp1.StatusCode, err)
 	}
 
-	resp2, err := app.Test(httptest.NewRequest(http.MethodGet, "/patients/"+seed.ID, nil))
+	resp2, err := app.Test(httptest.NewRequest(http.MethodGet, "/patients/"+seed.UID, nil))
 	if err != nil || resp2.StatusCode != fiber.StatusOK {
 		t.Fatalf("patient form page expected 200, got status=%d err=%v", resp2.StatusCode, err)
 	}
@@ -87,7 +87,7 @@ func TestPatientHandlersFlows(t *testing.T) {
 		"phone": {"444"},
 		"age":   {"31"},
 	}
-	req4 := httptest.NewRequest(http.MethodPost, "/patients/"+seed.ID+"/patch", strings.NewReader(updateForm.Encode()))
+	req4 := httptest.NewRequest(http.MethodPost, "/patients/"+seed.UID+"/patch", strings.NewReader(updateForm.Encode()))
 	req4.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req4.Header.Set("HX-Request", "true")
 	resp4, err := app.Test(req4)
@@ -95,14 +95,14 @@ func TestPatientHandlersFlows(t *testing.T) {
 		t.Fatalf("update patient expected 200 for htmx, got status=%d err=%v", resp4.StatusCode, err)
 	}
 
-	req5 := httptest.NewRequest(http.MethodPost, "/patients/"+seed.ID+"/removepic", nil)
+	req5 := httptest.NewRequest(http.MethodPost, "/patients/"+seed.UID+"/removepic", nil)
 	req5.Header.Set("HX-Request", "true")
 	resp5, err := app.Test(req5)
 	if err != nil || resp5.StatusCode != fiber.StatusOK {
 		t.Fatalf("remove pic expected 200 for htmx, got status=%d err=%v", resp5.StatusCode, err)
 	}
 
-	req6 := httptest.NewRequest(http.MethodPost, "/patients/"+seed.ID+"/delete", nil)
+	req6 := httptest.NewRequest(http.MethodPost, "/patients/"+seed.UID+"/delete", nil)
 	req6.Header.Set("HX-Request", "true")
 	resp6, err := app.Test(req6)
 	if err != nil || resp6.StatusCode != fiber.StatusOK {
@@ -133,7 +133,7 @@ func TestPatientProfilePicImageSourceHandler(t *testing.T) {
 		t.Fatalf("create patient: %v", err)
 	}
 
-	filename := patient.ID + "_ppic_avatar.png"
+	filename := patient.UID + "_ppic_avatar.png"
 	storagePath, err := ProfilePicPath(filename, assetsDir)
 	if err != nil {
 		t.Fatalf("profile pic path: %v", err)
@@ -142,7 +142,7 @@ func TestPatientProfilePicImageSourceHandler(t *testing.T) {
 		t.Fatalf("write profile pic file: %v", err)
 	}
 
-	if err := svc.DB.WithContext(t.Context()).Model(&models.Patient{}).Where("id = ?", patient.ID).Update("profile_pic", "/patients/"+patient.ID+"/profilepic/"+filename).Error; err != nil {
+	if err := svc.DB.WithContext(t.Context()).Model(&models.Patient{}).Where("id = ?", patient.ID).Update("profile_pic", "/patients/"+patient.UID+"/profilepic/"+filename).Error; err != nil {
 		t.Fatalf("attach patient profile pic: %v", err)
 	}
 
@@ -152,7 +152,7 @@ func TestPatientProfilePicImageSourceHandler(t *testing.T) {
 		return svc.HandlePatientProfilePicImgSrc(c)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/patients/"+patient.ID+"/profilepic/"+filename, nil))
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/patients/"+patient.UID+"/profilepic/"+filename, nil))
 	if err != nil || resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("profile pic src expected 200, got status=%d err=%v", resp.StatusCode, err)
 	}

--- a/internal/services/patient/inputs.go
+++ b/internal/services/patient/inputs.go
@@ -32,9 +32,10 @@ type patientUpsertInput struct {
 	ViaMessenger        bool `form:"viaMessenger"`
 }
 
-func (in patientUpsertInput) toPatient(id, userID string) models.Patient {
+func (in patientUpsertInput) toPatient(id uint, uid string, userID uint) models.Patient {
 	return models.Patient{
 		ID:                id,
+		UID:               uid,
 		UserID:            userID,
 		Name:              in.Name,
 		Email:             in.Email,

--- a/internal/services/patient/profile_pic.go
+++ b/internal/services/patient/profile_pic.go
@@ -21,8 +21,8 @@ func SaveProfilePicToDisk(c fiber.Ctx, patient models.Patient, assetsDir string)
 		return "", profilePicFormFileErr(err)
 	}
 
-	if patient.ID == "" {
-		return "", errors.New("failed to save profile pic without patient.ID")
+	if patient.UID == "" {
+		return "", errors.New("failed to save profile pic without patient.UID")
 	}
 
 	originalFilename := strings.TrimSpace(profilePic.Filename)
@@ -33,7 +33,7 @@ func SaveProfilePicToDisk(c fiber.Ctx, patient models.Patient, assetsDir string)
 		return "", ErrInvalidFilename
 	}
 
-	filename := patient.ID + "_ppic_" + safeFilename
+	filename := patient.UID + "_ppic_" + safeFilename
 	path, err := ProfilePicPath(filename, assetsDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to save profile pic without an ASSETS_DIR: %w", err)
@@ -44,7 +44,7 @@ func SaveProfilePicToDisk(c fiber.Ctx, patient models.Patient, assetsDir string)
 		return "", fmt.Errorf("failed to save profilePic to disk: %w", err)
 	}
 
-	imgsrc := "/patients/" + patient.ID + "/profilepic/" + filename
+	imgsrc := "/patients/" + patient.UID + "/profilepic/" + filename
 	return imgsrc, nil
 }
 

--- a/internal/services/patient/profile_pic_test.go
+++ b/internal/services/patient/profile_pic_test.go
@@ -131,7 +131,7 @@ func TestSaveProfilePicToDisk(t *testing.T) {
 	t.Run("returns ErrProfilePicNotProvided when form file missing", func(t *testing.T) {
 		app := fiber.New()
 		app.Post("/", func(c fiber.Ctx) error {
-			_, err := SaveProfilePicToDisk(c, models.Patient{ID: "pat_1"}, t.TempDir())
+			_, err := SaveProfilePicToDisk(c, models.Patient{UID: "pat_1"}, t.TempDir())
 			if !errors.Is(err, ErrProfilePicNotProvided) {
 				t.Fatalf("expected ErrProfilePicNotProvided, got %v", err)
 			}

--- a/internal/services/patient/service.go
+++ b/internal/services/patient/service.go
@@ -30,18 +30,18 @@ func NewService(s *server.Server) (service, error) {
 	}, nil
 }
 
-func (s service) TakePatientByID(ctx context.Context, userID, patientID string) (models.Patient, error) {
+func (s service) TakePatientByID(ctx context.Context, userID uint, patientID string) (models.Patient, error) {
 	patientID = strings.TrimSpace(patientID)
 	if patientID == "" {
 		return models.Patient{}, ErrIDRequired
 	}
 
 	return gorm.G[models.Patient](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientID, userID).
 		Take(ctx)
 }
 
-func (s service) PatientForShowPage(ctx context.Context, userID, patientID string) (models.Patient, error) {
+func (s service) PatientForShowPage(ctx context.Context, userID uint, patientID string) (models.Patient, error) {
 	patientID = strings.TrimSpace(patientID)
 	patient := models.Patient{}
 	if patientID == "" || patientID == "new" {
@@ -95,7 +95,7 @@ func (s service) CreatePatient(ctx context.Context, patient *models.Patient) err
 	return gorm.G[models.Patient](s.DB.GormDB()).Create(ctx, patient)
 }
 
-func (s service) UpdatePatientByID(ctx context.Context, userID, patientID string, patient models.Patient) error {
+func (s service) UpdatePatientByID(ctx context.Context, userID uint, patientID string, patient models.Patient) error {
 	patientID = strings.TrimSpace(patientID)
 	if patientID == "" {
 		return ErrIDRequired
@@ -106,7 +106,7 @@ func (s service) UpdatePatientByID(ctx context.Context, userID, patientID string
 	}
 
 	rowsAffected, err := gorm.G[models.Patient](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientID, userID).
 		Updates(ctx, patient)
 	if err != nil {
 		return err
@@ -126,14 +126,14 @@ func (s service) UpdatePatientByID(ctx context.Context, userID, patientID string
 	return nil
 }
 
-func (s service) DeletePatientByID(ctx context.Context, userID, patientID string) error {
+func (s service) DeletePatientByID(ctx context.Context, userID uint, patientID string) error {
 	patientID = strings.TrimSpace(patientID)
 	if patientID == "" {
 		return ErrIDRequired
 	}
 
 	rowsAffected, err := gorm.G[models.Patient](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientID, userID).
 		Delete(ctx)
 	if err != nil {
 		return err
@@ -145,14 +145,14 @@ func (s service) DeletePatientByID(ctx context.Context, userID, patientID string
 	return nil
 }
 
-func (s service) ClearPatientProfilePic(ctx context.Context, userID, patientID string) error {
+func (s service) ClearPatientProfilePic(ctx context.Context, userID uint, patientID string) error {
 	patientID = strings.TrimSpace(patientID)
 	if patientID == "" {
 		return ErrIDRequired
 	}
 
 	rowsAffected, err := gorm.G[models.Patient](s.DB.GormDB()).
-		Where("id = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientID, userID).
 		Update(ctx, "profile_pic", "")
 	if err != nil {
 		return err
@@ -172,7 +172,7 @@ func (s service) ClearPatientProfilePic(ctx context.Context, userID, patientID s
 	return nil
 }
 
-func (s service) patientExistsByID(ctx context.Context, userID, patientID string) (bool, error) {
+func (s service) patientExistsByID(ctx context.Context, userID uint, patientID string) (bool, error) {
 	patientID = strings.TrimSpace(patientID)
 	if patientID == "" {
 		return false, ErrIDRequired
@@ -181,7 +181,7 @@ func (s service) patientExistsByID(ctx context.Context, userID, patientID string
 	var count int64
 	err := s.DB.WithContext(ctx).
 		Model(&models.Patient{}).
-		Where("id = ? AND user_id = ?", patientID, userID).
+		Where("uid = ? AND user_id = ?", patientID, userID).
 		Count(&count).Error
 	if err != nil {
 		return false, err

--- a/internal/services/patient/service_db_test.go
+++ b/internal/services/patient/service_db_test.go
@@ -28,16 +28,16 @@ func TestPatientServiceDBFlows(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected empty show page patient without error, got %v", err)
 		}
-		if showPatient.ID != "" {
-			t.Fatalf("expected zero patient id for empty show page id, got %q", showPatient.ID)
+		if showPatient.UID != "" {
+			t.Fatalf("expected zero patient uid for empty show page id, got %q", showPatient.UID)
 		}
 
 		showPatient, err = svc.PatientForShowPage(ctx, user.ID, "new")
 		if err != nil {
 			t.Fatalf("expected new show page patient without error, got %v", err)
 		}
-		if showPatient.ID != "" {
-			t.Fatalf("expected zero patient id for new show page id, got %q", showPatient.ID)
+		if showPatient.UID != "" {
+			t.Fatalf("expected zero patient uid for new show page id, got %q", showPatient.UID)
 		}
 	})
 
@@ -71,7 +71,7 @@ func TestPatientServiceDBFlows(t *testing.T) {
 
 	t.Run("update patient and clear profile pic", func(t *testing.T) {
 		upd := models.Patient{Name: "Alpha Updated", Email: "updated@example.com", Phone: "999"}
-		if err := svc.UpdatePatientByID(ctx, user.ID, base.ID, upd); err != nil {
+		if err := svc.UpdatePatientByID(ctx, user.ID, base.UID, upd); err != nil {
 			t.Fatalf("update patient: %v", err)
 		}
 
@@ -79,14 +79,14 @@ func TestPatientServiceDBFlows(t *testing.T) {
 			t.Fatalf("expected record not found on missing update, got %v", err)
 		}
 
-		if err := svc.UpdatePatientByID(ctx, user.ID, base.ID, models.Patient{Name: "N", Phone: "1", Email: strings.Repeat("e", 255)}); err == nil {
+		if err := svc.UpdatePatientByID(ctx, user.ID, base.UID, models.Patient{Name: "N", Phone: "1", Email: strings.Repeat("e", 255)}); err == nil {
 			t.Fatalf("expected normalization error on long email")
 		}
 
-		if err := svc.UpdatePatientByID(ctx, user.ID, base.ID, models.Patient{ProfilePic: "avatar.png", Name: "Alpha Updated", Email: "updated@example.com", Phone: "999"}); err != nil {
+		if err := svc.UpdatePatientByID(ctx, user.ID, base.UID, models.Patient{ProfilePic: "avatar.png", Name: "Alpha Updated", Email: "updated@example.com", Phone: "999"}); err != nil {
 			t.Fatalf("update profile pic: %v", err)
 		}
-		if err := svc.ClearPatientProfilePic(ctx, user.ID, base.ID); err != nil {
+		if err := svc.ClearPatientProfilePic(ctx, user.ID, base.UID); err != nil {
 			t.Fatalf("clear profile pic: %v", err)
 		}
 		if err := svc.ClearPatientProfilePic(ctx, user.ID, "missing"); err != gorm.ErrRecordNotFound {
@@ -106,10 +106,10 @@ func TestPatientServiceDBFlows(t *testing.T) {
 			t.Fatalf("expected 2 rows affected, got %d", rows)
 		}
 
-		if err := svc.DeletePatientByID(ctx, user.ID, base.ID); err != nil {
+		if err := svc.DeletePatientByID(ctx, user.ID, base.UID); err != nil {
 			t.Fatalf("delete patient: %v", err)
 		}
-		if err := svc.DeletePatientByID(ctx, user.ID, base.ID); err != gorm.ErrRecordNotFound {
+		if err := svc.DeletePatientByID(ctx, user.ID, base.UID); err != gorm.ErrRecordNotFound {
 			t.Fatalf("expected not found on repeated delete, got %v", err)
 		}
 	})
@@ -120,7 +120,7 @@ func TestPatientServiceDBFlows(t *testing.T) {
 			t.Fatalf("create patient for exists helper: %v", err)
 		}
 
-		exists, err := svc.patientExistsByID(ctx, user.ID, p.ID)
+		exists, err := svc.patientExistsByID(ctx, user.ID, p.UID)
 		if err != nil {
 			t.Fatalf("patient exists check: %v", err)
 		}

--- a/internal/services/patient/service_inputs_test.go
+++ b/internal/services/patient/service_inputs_test.go
@@ -30,8 +30,8 @@ func TestPatientUpsertInputToPatient(t *testing.T) {
 		ViaMessenger:        true,
 	}
 
-	patient := in.toPatient("pat_1", "usr_1")
-	if patient.ID != "pat_1" || patient.UserID != "usr_1" {
+	patient := in.toPatient(1, "pat_1", 2)
+	if patient.ID != 1 || patient.UID != "pat_1" || patient.UserID != 2 {
 		t.Fatalf("unexpected identifiers mapping: %#v", patient)
 	}
 	if patient.Name != in.Name || patient.Email != in.Email || patient.Ocupation != in.Ocupation {

--- a/internal/services/patient/service_validation_test.go
+++ b/internal/services/patient/service_validation_test.go
@@ -13,29 +13,29 @@ func TestServiceValidationGuards(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("id-required methods return ErrIDRequired on blank id", func(t *testing.T) {
-		if _, err := svc.TakePatientByID(ctx, "usr_1", "   "); !errors.Is(err, ErrIDRequired) {
+		if _, err := svc.TakePatientByID(ctx, 1, "   "); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for TakePatientByID, got %v", err)
 		}
-		if err := svc.UpdatePatientByID(ctx, "usr_1", "", models.Patient{}); !errors.Is(err, ErrIDRequired) {
+		if err := svc.UpdatePatientByID(ctx, 1, "", models.Patient{}); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for UpdatePatientByID, got %v", err)
 		}
-		if err := svc.DeletePatientByID(ctx, "usr_1", ""); !errors.Is(err, ErrIDRequired) {
+		if err := svc.DeletePatientByID(ctx, 1, ""); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for DeletePatientByID, got %v", err)
 		}
-		if err := svc.ClearPatientProfilePic(ctx, "usr_1", ""); !errors.Is(err, ErrIDRequired) {
+		if err := svc.ClearPatientProfilePic(ctx, 1, ""); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for ClearPatientProfilePic, got %v", err)
 		}
-		if _, err := svc.patientExistsByID(ctx, "usr_1", ""); !errors.Is(err, ErrIDRequired) {
+		if _, err := svc.patientExistsByID(ctx, 1, ""); !errors.Is(err, ErrIDRequired) {
 			t.Fatalf("expected ErrIDRequired for patientExistsByID, got %v", err)
 		}
 	})
 
 	t.Run("PatientForShowPage short-circuits for create flow", func(t *testing.T) {
-		patient, err := svc.PatientForShowPage(ctx, "usr_1", "new")
+		patient, err := svc.PatientForShowPage(ctx, 1, "new")
 		if err != nil {
 			t.Fatalf("expected nil error for new patient page, got %v", err)
 		}
-		if patient.ID != "" {
+		if patient.ID != 0 {
 			t.Fatalf("expected zero patient for new page, got %+v", patient)
 		}
 	})

--- a/internal/services/user/handlers.go
+++ b/internal/services/user/handlers.go
@@ -67,7 +67,7 @@ func (s *service) HandleUpdateProfile(c fiber.Ctx) error {
 	}
 
 	userUpds := input.toUserProfileUpdates()
-	updatedUser, err := s.UpdateUserProfileByID(c.Context(), cu.ID, userUpds)
+	updatedUser, err := s.UpdateUserProfileByID(c.Context(), cu.UID, userUpds)
 	if errors.Is(err, ErrIDRequired) || errors.Is(err, gorm.ErrRecordNotFound) {
 		return s.respondWithRedirect(c, "/profile?toast=User does not exist&level=warning", fiber.StatusNotFound)
 	}

--- a/internal/services/user/handlers_branches_test.go
+++ b/internal/services/user/handlers_branches_test.go
@@ -74,7 +74,7 @@ func TestHandleEditPageSuccess(t *testing.T) {
 		return svc.HandleEditPage(c)
 	})
 
-	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/admin/users/"+currentUser.ID, nil))
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/admin/users/"+currentUser.UID, nil))
 	if err != nil || resp.StatusCode != fiber.StatusOK {
 		t.Fatalf("edit page existing user expected 200, got status=%d err=%v", resp.StatusCode, err)
 	}

--- a/internal/services/user/service.go
+++ b/internal/services/user/service.go
@@ -41,7 +41,7 @@ func (s service) TakeUserByID(ctx context.Context, userID string) (models.User, 
 		return models.User{}, ErrIDRequired
 	}
 
-	user, err := gorm.G[models.User](s.DB.GormDB()).Where("id = ?", userID).Take(ctx)
+	user, err := gorm.G[models.User](s.DB.GormDB()).Where("uid = ?", userID).Take(ctx)
 	if err != nil {
 		return models.User{}, err
 	}
@@ -61,7 +61,7 @@ func (s service) UpdateUserProfileByID(ctx context.Context, userID string, updat
 	}
 
 	rowsAffected, err := gorm.G[models.User](s.DB.GormDB()).
-		Where("id = ?", userID).
+		Where("uid = ?", userID).
 		Updates(ctx, updates)
 	if err != nil {
 		return models.User{}, err

--- a/internal/services/user/service_db_test.go
+++ b/internal/services/user/service_db_test.go
@@ -19,12 +19,12 @@ func TestUserServiceDBFlows(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("take user and find recent users", func(t *testing.T) {
-		got, err := svc.TakeUserByID(ctx, seededUser.ID)
+		got, err := svc.TakeUserByID(ctx, seededUser.UID)
 		if err != nil {
 			t.Fatalf("take user by id: %v", err)
 		}
-		if got.ID != seededUser.ID {
-			t.Fatalf("expected user id %q, got %q", seededUser.ID, got.ID)
+		if got.UID != seededUser.UID {
+			t.Fatalf("expected user uid %q, got %q", seededUser.UID, got.UID)
 		}
 
 		users, err := svc.FindRecentUsers(ctx, 10)
@@ -38,7 +38,7 @@ func TestUserServiceDBFlows(t *testing.T) {
 
 	t.Run("update user profile branches", func(t *testing.T) {
 		updates := models.User{Name: "  New Name  ", Email: " NEW@EXAMPLE.COM ", Phone: " 999 "}
-		updated, err := svc.UpdateUserProfileByID(ctx, seededUser.ID, updates)
+		updated, err := svc.UpdateUserProfileByID(ctx, seededUser.UID, updates)
 		if err != nil {
 			t.Fatalf("update user profile: %v", err)
 		}

--- a/internal/views/appointmentconfirmpage.templ
+++ b/internal/views/appointmentconfirmpage.templ
@@ -60,7 +60,7 @@ templ AppointmentCancelPage(vc *Ctx, appointment models.Appointment) {
 					</p>
 					<div class="mt-10 flex items-center justify-center gap-x-6">
 						if appointment.CanceledAt.IsZero() {
-							<form action={ templ.URL("/appointments/" + appointment.ID + "/patient/cancel/" + appointment.Token) } method="POST" hx-boost="true">
+							<form action={ templ.URL("/appointments/" + appointment.UID + "/patient/cancel/" + appointment.Token) } method="POST" hx-boost="true">
 								<button type="submit" class="btn btn-secondary">{ l(vc.Locale, "str.yes_cancel_my_appointment") }</button>
 							</form>
 						} else {

--- a/internal/views/appointmentconfirmpage_templ.go
+++ b/internal/views/appointmentconfirmpage_templ.go
@@ -231,9 +231,9 @@ func AppointmentCancelPage(vc *Ctx, appointment models.Appointment) templ.Compon
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var11 templ.SafeURL
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.ID + "/patient/cancel/" + appointment.Token))
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.UID + "/patient/cancel/" + appointment.Token))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentconfirmpage.templ`, Line: 63, Col: 107}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentconfirmpage.templ`, Line: 63, Col: 108}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {

--- a/internal/views/appointmentspage.templ
+++ b/internal/views/appointmentspage.templ
@@ -37,7 +37,7 @@ templ AppointmentsPage(vc *Ctx, appointments []models.Appointment, selectedPatie
 templ AppointmentPage(vc *Ctx, appointment models.Appointment, patients []models.Patient, clinics []models.Clinic) {
 	@LayoutWithBackBtn(vc, "/appointments") {
 		<section id="appointment_profile_cont" class="grow flex flex-col px-0 sm:px-4 md:px-8 md:py-8 lg:justify-center lg:w-2/3 lg:max-w-4xl lg:mx-auto">
-			if appointment.ID == "" || appointment.ID == "new" {
+			if appointment.UID == "" || appointment.UID == "new" {
 				<h1 class="px-4 sm:px-0 font-bold text-2xl pb-0 w-full">{ l(vc.Locale, "str.new_appointment") }</h1>
 			} else {
 				<h1 class="px-4 sm:px-0 font-bold text-2xl pb-0 w-full">{ l(vc.Locale, "str.edit_appointment") }</h1>
@@ -172,7 +172,7 @@ templ AppointmentLi(vc *Ctx, appointment models.Appointment) {
 		</figure>
 		<div class="flex-auto">
 			<hgroup class="flex items-center gap-2">
-				<a href={ templ.URL("/appointments" + QueryParams(vc, "patientId="+appointment.PatientID)) } class="link link-hover">
+				<a href={ templ.URL("/appointments" + QueryParams(vc, "patientId="+appointment.Patient.UID)) } class="link link-hover">
 					<h3 class="font-semibold text-base-content xl:pr-0">
 						{ appointment.Patient.Name }
 					</h3>
@@ -242,13 +242,13 @@ templ AppointmentLi(vc *Ctx, appointment models.Appointment) {
 
 templ AppointmentActions(appointment models.Appointment, vc *Ctx) {
 	<div class="hidden gap-2 items-center lg:flex">
-		<a href={ templ.URL("/appointments/" + appointment.ID + "/start") } class="btn btn-outline btn-primary">
+		<a href={ templ.URL("/appointments/" + appointment.UID + "/start") } class="btn btn-outline btn-primary">
 			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"></path>
 			</svg>
 			{ l(vc.Locale, "btn.open") }
 		</a>
-		<a href={ templ.URL("/appointments/" + appointment.ID) } class="btn btn-outline btn-secondary">
+		<a href={ templ.URL("/appointments/" + appointment.UID) } class="btn btn-outline btn-secondary">
 			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
 				<path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"></path>
 			</svg>
@@ -290,7 +290,7 @@ templ AppointmentCont(vc *Ctx, appointment models.Appointment, patients []models
 			</div>
 			<section class="relative bg-base-100 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
 				@AppointmentForm(appointment, vc) {
-					<input type="hidden" name="id" value={ appointment.ID } id="apnt_datetime_id"/>
+					<input type="hidden" name="id" value={ appointment.UID } id="apnt_datetime_id"/>
 					<div class="px-4 py-6 sm:p-8">
 						<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
 							<div class="sm:col-span-4">
@@ -443,11 +443,11 @@ templ ApptSearchClinicsResults(vc *Ctx, clinics []models.Clinic) {
 						type="radio"
 						class="radio"
 						form="new_appointment"
-						value={ clinic.ID }
+						value={ clinic.UID }
 						if i == 0 {
 							checked
 						}
-						hx-get={ "/appointments/new/pricefrg/" + clinic.ID }
+						hx-get={ "/appointments/new/pricefrg/" + clinic.UID }
 						hx-trigger="click"
 					/>
 				</label>
@@ -520,7 +520,7 @@ templ PatientSearchResults(patients []models.Patient, vc *Ctx) {
 						type="radio"
 						class="radio"
 						form="new_appointment"
-						value={ patient.ID }
+						value={ patient.UID }
 						if i == 0 {
 							checked
 						}
@@ -541,9 +541,9 @@ templ AppointmentForm(appointment models.Appointment, vc *Ctx) {
 		id="new_appointment"
 		method="POST"
 		enctype="multipart/form-data"
-		if appointment.ID != "" && appointment.ID != "new" {
-			hx-patch={ "/appointments/" + appointment.ID }
-			action={ templ.URL("/appointments/" + appointment.ID + "/patch") }
+		if appointment.UID != "" && appointment.UID != "new" {
+			hx-patch={ "/appointments/" + appointment.UID }
+			action={ templ.URL("/appointments/" + appointment.UID + "/patch") }
 		} else {
 			hx-post="/appointments"
 			action="/appointments"

--- a/internal/views/appointmentspage_templ.go
+++ b/internal/views/appointmentspage_templ.go
@@ -133,7 +133,7 @@ func AppointmentPage(vc *Ctx, appointment models.Appointment, patients []models.
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if appointment.ID == "" || appointment.ID == "new" {
+			if appointment.UID == "" || appointment.UID == "new" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<h1 class=\"px-4 sm:px-0 font-bold text-2xl pb-0 w-full\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -881,9 +881,9 @@ func AppointmentLi(vc *Ctx, appointment models.Appointment) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var57 templ.SafeURL
-		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments" + QueryParams(vc, "patientId="+appointment.PatientID)))
+		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments" + QueryParams(vc, "patientId="+appointment.Patient.UID)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 175, Col: 94}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 175, Col: 96}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 		if templ_7745c5c3_Err != nil {
@@ -1028,9 +1028,9 @@ func AppointmentActions(appointment models.Appointment, vc *Ctx) templ.Component
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var64 templ.SafeURL
-		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.ID + "/start"))
+		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.UID + "/start"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 245, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 245, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 		if templ_7745c5c3_Err != nil {
@@ -1054,9 +1054,9 @@ func AppointmentActions(appointment models.Appointment, vc *Ctx) templ.Component
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var66 templ.SafeURL
-		templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.ID))
+		templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 251, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 251, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 		if templ_7745c5c3_Err != nil {
@@ -1269,9 +1269,9 @@ func AppointmentCont(vc *Ctx, appointment models.Appointment, patients []models.
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var78 string
-			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(appointment.ID)
+			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(appointment.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 293, Col: 58}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 293, Col: 59}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 			if templ_7745c5c3_Err != nil {
@@ -1658,9 +1658,9 @@ func ApptSearchClinicsResults(vc *Ctx, clinics []models.Clinic) templ.Component 
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var97 string
-			templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(clinic.ID)
+			templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(clinic.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 446, Col: 23}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 446, Col: 24}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
 			if templ_7745c5c3_Err != nil {
@@ -1681,9 +1681,9 @@ func ApptSearchClinicsResults(vc *Ctx, clinics []models.Clinic) templ.Component 
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var98 string
-			templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs("/appointments/new/pricefrg/" + clinic.ID)
+			templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs("/appointments/new/pricefrg/" + clinic.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 450, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 450, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
 			if templ_7745c5c3_Err != nil {
@@ -1884,9 +1884,9 @@ func PatientSearchResults(patients []models.Patient, vc *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var107 string
-			templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(patient.ID)
+			templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(patient.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 523, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 523, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 			if templ_7745c5c3_Err != nil {
@@ -1959,15 +1959,15 @@ func AppointmentForm(appointment models.Appointment, vc *Ctx) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if appointment.ID != "" && appointment.ID != "new" {
+		if appointment.UID != "" && appointment.UID != "new" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, " hx-patch=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var110 string
-			templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs("/appointments/" + appointment.ID)
+			templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs("/appointments/" + appointment.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 545, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 545, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var110))
 			if templ_7745c5c3_Err != nil {
@@ -1978,9 +1978,9 @@ func AppointmentForm(appointment models.Appointment, vc *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var111 templ.SafeURL
-			templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.ID + "/patch"))
+			templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.UID + "/patch"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 546, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentspage.templ`, Line: 546, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
 			if templ_7745c5c3_Err != nil {

--- a/internal/views/appointmentstartpage.templ
+++ b/internal/views/appointmentstartpage.templ
@@ -95,15 +95,15 @@ templ AppointmentStart(appointment models.Appointment, vc *Ctx) {
 				<h1 class="font-bold text-2xl">{ l(vc.Locale, "str.current_session") }</h1>
 			</hgroup>
 			<section class="relative bg-base-100 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl">
-				<input type="hidden" name="id" value={ appointment.ID } id="mb_appointment_id"/>
+				<input type="hidden" name="id" value={ appointment.UID } id="mb_appointment_id"/>
 				<div class="flex justify-end p-4 pb-0 text-base-content/50">
 					@CmpTime(appointment.BookedAt)
 				</div>
 				<form
 					id="patch_appointment"
 					method="POST"
-					action={ templ.URL("/appointments/" + appointment.ID + "/complete") }
-					hx-post={ "/appointments/" + appointment.ID + "/complete" }
+					action={ templ.URL("/appointments/" + appointment.UID + "/complete") }
+					hx-post={ "/appointments/" + appointment.UID + "/complete" }
 				>
 					<div class="px-4 py-6 sm:p-8">
 						<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
@@ -158,8 +158,8 @@ templ AppointmentStart(appointment models.Appointment, vc *Ctx) {
 					<form
 						id="cancel_appointment"
 						method="POST"
-						action={ templ.URL("/appointments/" + appointment.ID + "/cancel") }
-						hx-post={ "/appointments/" + appointment.ID + "/cancel" }
+						action={ templ.URL("/appointments/" + appointment.UID + "/cancel") }
+						hx-post={ "/appointments/" + appointment.UID + "/cancel" }
 						hx-confirm={ l(vc.Locale, "str.are_you_sure") }
 					>
 						<button

--- a/internal/views/appointmentstartpage_templ.go
+++ b/internal/views/appointmentstartpage_templ.go
@@ -302,9 +302,9 @@ func AppointmentStart(appointment models.Appointment, vc *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var15 string
-		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(appointment.ID)
+		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(appointment.UID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 98, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 98, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -323,9 +323,9 @@ func AppointmentStart(appointment models.Appointment, vc *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var16 templ.SafeURL
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.ID + "/complete"))
+		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.UID + "/complete"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 105, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 105, Col: 73}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
@@ -336,9 +336,9 @@ func AppointmentStart(appointment models.Appointment, vc *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
-		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("/appointments/" + appointment.ID + "/complete")
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("/appointments/" + appointment.UID + "/complete")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 106, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 106, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -505,9 +505,9 @@ func AppointmentStart(appointment models.Appointment, vc *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var30 templ.SafeURL
-		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.ID + "/cancel"))
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments/" + appointment.UID + "/cancel"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 161, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 161, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {
@@ -518,9 +518,9 @@ func AppointmentStart(appointment models.Appointment, vc *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var31 string
-		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs("/appointments/" + appointment.ID + "/cancel")
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs("/appointments/" + appointment.UID + "/cancel")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 162, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/appointmentstartpage.templ`, Line: 162, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {

--- a/internal/views/clinicspage.templ
+++ b/internal/views/clinicspage.templ
@@ -53,7 +53,7 @@ templ ClinicPage(vc *Ctx, clinic models.Clinic) {
 			@CmpBtnBack(l(vc.Locale, "btn.back"), "/clinics")
 		</div>
 		<section id="clinic_profile_cont" class="grow flex flex-col px-0 sm:px-4 md:px-8 py-8 lg:justify-center lg:w-2/3 lg:max-w-4xl lg:mx-auto">
-			if clinic.ID == "" || clinic.ID == "new" {
+			if clinic.UID == "" || clinic.UID == "new" {
 				<h1 class="px-4 sm:px-0 font-bold text-2xl pb-0 w-full">{ l(vc.Locale, "str.new_clinic") }</h1>
 			} else {
 				<h1 class="px-4 sm:px-0 font-bold text-2xl pb-0 w-full inline-flex">
@@ -119,7 +119,7 @@ templ ClinicLi(clinic models.Clinic, vc *Ctx) {
 			<div class="hidden sm:flex sm:flex-col sm:items-end">
 				<div class="flex gap-2 z-10 mb-2">
 					<a
-						href={ templ.URL("/appointments?clinicId=" + clinic.ID) }
+						href={ templ.URL("/appointments?clinicId=" + clinic.UID) }
 						class="btn btn-outline btn-primary"
 					>
 						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
@@ -129,7 +129,7 @@ templ ClinicLi(clinic models.Clinic, vc *Ctx) {
 					</a>
 					<a
 						class="btn btn-outline btn-secondary"
-						href={ templ.URL("/clinics/" + clinic.ID) }
+						href={ templ.URL("/clinics/" + clinic.UID) }
 						hx-boost="true"
 					>
 						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
@@ -147,8 +147,8 @@ templ ClinicDeleteForm(vc *Ctx, clinic models.Clinic) {
 	<form
 		class="ml-auto"
 		method="POST"
-		action={ templ.URL("/clinics/"+clinic.ID) + "/delete" }
-		hx-delete={ "/clinics/" + clinic.ID }
+		action={ templ.URL("/clinics/"+clinic.UID) + "/delete" }
+		hx-delete={ "/clinics/" + clinic.UID }
 		hx-confirm={ l(vc.Locale, "str.are_you_sure") }
 		hx-target="this"
 		hx-swap="none"
@@ -188,7 +188,7 @@ templ ClinicProfile(clinic models.Clinic, vc *Ctx) {
 				<p class="mt-1 text-sm leading-6 text-base-content/60">{ l(vc.Locale, "str.clinic_info_desc") }</p>
 			</div>
 			@ClinicForm(clinic, vc) {
-				<input type="hidden" name="id" value={ clinic.ID } id="pi_clinic_id"/>
+				<input type="hidden" name="id" value={ clinic.UID } id="pi_clinic_id"/>
 				<div class="px-4 py-6 sm:p-8">
 					<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
 						<div class="col-span-full">
@@ -297,7 +297,7 @@ templ ClinicProfile(clinic models.Clinic, vc *Ctx) {
 				<p class="mt-1 text-sm leading-6 text-base-content/60">{ l(vc.Locale, "str.address_desc") }</p>
 			</div>
 			@ClinicForm(clinic, vc) {
-				<input type="hidden" name="id" value={ clinic.ID } id="address_clinic_id"/>
+				<input type="hidden" name="id" value={ clinic.UID } id="address_clinic_id"/>
 				<div class="px-4 py-6 sm:p-8">
 					<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
 						<div class="col-span-full">
@@ -349,7 +349,7 @@ templ ClinicProfile(clinic models.Clinic, vc *Ctx) {
 				<p class="mt-1 text-sm leading-6 text-base-content/60">{ l(vc.Locale, "str.social_media_desc") }</p>
 			</div>
 			@ClinicForm(clinic, vc) {
-				<input type="hidden" name="id" value={ clinic.ID } id="mb_clinic_id"/>
+				<input type="hidden" name="id" value={ clinic.UID } id="mb_clinic_id"/>
 				<div class="px-4 py-6 sm:p-8">
 					<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
 						<div class="sm:col-span-4">
@@ -392,12 +392,12 @@ templ ClinicForm(clinic models.Clinic, vc *Ctx) {
 		class="relative bg-base-100 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2"
 		method="POST"
 		enctype="multipart/form-data"
-		if clinic.ID == "" || clinic.ID == "new" {
+		if clinic.UID == "" || clinic.UID == "new" {
 			hx-post="/clinics"
 			action="/clinics"
 		} else {
-			hx-patch={ "/clinics/" + clinic.ID }
-			action={ templ.URL("/clinics/" + clinic.ID + "/patch") }
+			hx-patch={ "/clinics/" + clinic.UID }
+			action={ templ.URL("/clinics/" + clinic.UID + "/patch") }
 		}
 		hx-target="closest #clinic_profile_cont"
 		hx-select="#clinic_profile_cont"

--- a/internal/views/clinicspage_templ.go
+++ b/internal/views/clinicspage_templ.go
@@ -167,7 +167,7 @@ func ClinicPage(vc *Ctx, clinic models.Clinic) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if clinic.ID == "" || clinic.ID == "new" {
+			if clinic.UID == "" || clinic.UID == "new" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<h1 class=\"px-4 sm:px-0 font-bold text-2xl pb-0 w-full\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -368,9 +368,9 @@ func ClinicLi(clinic models.Clinic, vc *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var16 templ.SafeURL
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments?clinicId=" + clinic.ID))
+		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments?clinicId=" + clinic.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 122, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 122, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
@@ -394,9 +394,9 @@ func ClinicLi(clinic models.Clinic, vc *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 templ.SafeURL
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/clinics/" + clinic.ID))
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/clinics/" + clinic.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 132, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 132, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -449,9 +449,9 @@ func ClinicDeleteForm(vc *Ctx, clinic models.Clinic) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 templ.SafeURL
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/clinics/"+clinic.ID) + "/delete")
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/clinics/"+clinic.UID) + "/delete")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 150, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 150, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -462,9 +462,9 @@ func ClinicDeleteForm(vc *Ctx, clinic models.Clinic) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("/clinics/" + clinic.ID)
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("/clinics/" + clinic.UID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 151, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 151, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
@@ -601,9 +601,9 @@ func ClinicProfile(clinic models.Clinic, vc *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var30 string
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(clinic.ID)
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(clinic.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 191, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 191, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
@@ -966,9 +966,9 @@ func ClinicProfile(clinic models.Clinic, vc *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var54 string
-			templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(clinic.ID)
+			templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(clinic.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 300, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 300, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 			if templ_7745c5c3_Err != nil {
@@ -1194,9 +1194,9 @@ func ClinicProfile(clinic models.Clinic, vc *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var69 string
-			templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(clinic.ID)
+			templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(clinic.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 352, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 352, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 			if templ_7745c5c3_Err != nil {
@@ -1375,7 +1375,7 @@ func ClinicForm(clinic models.Clinic, vc *Ctx) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if clinic.ID == "" || clinic.ID == "new" {
+		if clinic.UID == "" || clinic.UID == "new" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, " hx-post=\"/clinics\" action=\"/clinics\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -1386,9 +1386,9 @@ func ClinicForm(clinic models.Clinic, vc *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var81 string
-			templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs("/clinics/" + clinic.ID)
+			templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs("/clinics/" + clinic.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 399, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 399, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 			if templ_7745c5c3_Err != nil {
@@ -1399,9 +1399,9 @@ func ClinicForm(clinic models.Clinic, vc *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var82 templ.SafeURL
-			templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/clinics/" + clinic.ID + "/patch"))
+			templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/clinics/" + clinic.UID + "/patch"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 400, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/clinicspage.templ`, Line: 400, Col: 58}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 			if templ_7745c5c3_Err != nil {

--- a/internal/views/dashboardpage.templ
+++ b/internal/views/dashboardpage.templ
@@ -121,7 +121,7 @@ templ MonthTrends(stats DashboardStats, vc *Ctx) {
 }
 
 templ Clinic(c *Ctx, clinic models.Clinic) {
-	if clinic.ID != "" {
+	if clinic.UID != "" {
 		<div class="app-card">
 			<div class="relative flex flex-wrap">
 				<div class="flex items-center w-full gap-2 justify-between mb-6">

--- a/internal/views/dashboardpage_templ.go
+++ b/internal/views/dashboardpage_templ.go
@@ -369,7 +369,7 @@ func Clinic(c *Ctx, clinic models.Clinic) templ.Component {
 			templ_7745c5c3_Var21 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		if clinic.ID != "" {
+		if clinic.UID != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div class=\"app-card\"><div class=\"relative flex flex-wrap\"><div class=\"flex items-center w-full gap-2 justify-between mb-6\"><h3 class=\"font-semibold text-xl leading-6 indicator mr-32\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err

--- a/internal/views/patientspage.templ
+++ b/internal/views/patientspage.templ
@@ -58,13 +58,13 @@ templ PatientFormPage(patient models.Patient, c *Ctx) {
 				class="flex justify-between items-center pb-4 pl-4 sm:pl-0"
 				hx-boost="true"
 			>
-				if patient.ID == "" || patient.ID == "new" {
+				if patient.UID == "" || patient.UID == "new" {
 					<h1 class="font-bold text-2xl">{ c.l("str.new_patient") }</h1>
 				} else {
 					<h1 class="font-bold text-2xl">{ c.l("str.edit_patient") }</h1>
 				}
 				<a
-					href={ templ.URL("/appointments?patientId=" + patient.ID) }
+					href={ templ.URL("/appointments?patientId=" + patient.UID) }
 					class="btn btn-primary btn-sm"
 				>
 					@IconCalendar("")
@@ -147,7 +147,7 @@ templ PatientLi(patient models.Patient, c *Ctx) {
 				<div class="flex gap-2 z-10 mb-2">
 					<a
 						class="btn btn-outline btn-primary"
-						href={ templ.URL("/appointments?patientId=" + patient.ID) }
+						href={ templ.URL("/appointments?patientId=" + patient.UID) }
 					>
 						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
 							<path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"></path>
@@ -156,7 +156,7 @@ templ PatientLi(patient models.Patient, c *Ctx) {
 					</a>
 					<a
 						class="btn btn-outline btn-secondary"
-						href={ templ.URL("/patients/" + patient.ID) }
+						href={ templ.URL("/patients/" + patient.UID) }
 						hx-boost="true"
 					>
 						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
@@ -173,8 +173,8 @@ templ PatientLi(patient models.Patient, c *Ctx) {
 templ PatientDeleteForm(patient models.Patient, c *Ctx) {
 	<form
 		method="POST"
-		action={ templ.URL("/patients/"+patient.ID) + "/delete" }
-		hx-delete={ "/patients/" + patient.ID }
+		action={ templ.URL("/patients/"+patient.UID) + "/delete" }
+		hx-delete={ "/patients/" + patient.UID }
 		hx-confirm={ c.l("str.are_you_sure") }
 		hx-target="#patients_list"
 	>
@@ -213,7 +213,7 @@ templ PatientProfile(patient models.Patient, c *Ctx) {
 				<p class="mt-1 text-sm leading-6 text-base-content/60">{ c.l("str.personal_info_desc") }</p>
 			</div>
 			@PatientForm(c, patient) {
-				<input type="hidden" name="id" value={ patient.ID } id="pi_patient_id"/>
+				<input type="hidden" name="id" value={ patient.UID } id="pi_patient_id"/>
 				<div class="px-4 py-6 sm:p-8">
 					<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
 						<div class="col-span-full">
@@ -223,8 +223,8 @@ templ PatientProfile(patient models.Patient, c *Ctx) {
 									<figure class="flex flex-col gap-1 items-center" id="avatar_pic">
 										@CmpAvatar(patient)
 										<a
-											href={ templ.URL("/patients/" + patient.ID + "/removepic") }
-											hx-patch={ "/patients/" + patient.ID + "/removepic" }
+										href={ templ.URL("/patients/" + patient.UID + "/removepic") }
+										hx-patch={ "/patients/" + patient.UID + "/removepic" }
 											hx-select="#avatar_pic"
 											hx-swap="outerHTML"
 											hx-target="closest figure"
@@ -339,7 +339,7 @@ templ PatientProfile(patient models.Patient, c *Ctx) {
 				<p class="mt-1 text-sm leading-6 text-base-content/60">{ c.l("str.address_desc") }</p>
 			</div>
 			@PatientForm(c, patient) {
-				<input type="hidden" name="id" value={ patient.ID } id="address_patient_id"/>
+				<input type="hidden" name="id" value={ patient.UID } id="address_patient_id"/>
 				<div class="px-4 py-6 sm:p-8">
 					<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
 						<div class="col-span-full">
@@ -390,7 +390,7 @@ templ PatientProfile(patient models.Patient, c *Ctx) {
 				<p class="mt-1 text-sm leading-6 text-base-content/60">{ c.l("str.medical_profile_desc") }</p>
 			</div>
 			@PatientForm(c, patient) {
-				<input type="hidden" name="id" value={ patient.ID } id="mb_patient_id"/>
+				<input type="hidden" name="id" value={ patient.UID } id="mb_patient_id"/>
 				<div class="px-4 py-6 sm:p-8">
 					<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
 						<div class="col-span-full">
@@ -438,7 +438,7 @@ templ PatientProfile(patient models.Patient, c *Ctx) {
 				<p class="mt-1 text-sm leading-6">{ c.l("str.notifications_desc") }</p>
 			</div>
 			@PatientForm(c, patient) {
-				<input type="hidden" name="id" value={ patient.ID } id="no_patient_id"/>
+				<input type="hidden" name="id" value={ patient.UID } id="no_patient_id"/>
 				<div class="px-4 py-6 sm:p-8">
 					<div class="max-w-2xl space-y-10">
 						<fieldset>
@@ -541,9 +541,9 @@ templ PatientForm(c *Ctx, patient models.Patient) {
 		class="relative bg-base-100 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2"
 		method="POST"
 		enctype="multipart/form-data"
-		if patient.ID != "" && patient.ID != "new" {
-			hx-patch={ "/patients/" + patient.ID }
-			action={ templ.URL("/patients/" + patient.ID + "/patch") }
+		if patient.UID != "" && patient.UID != "new" {
+			hx-patch={ "/patients/" + patient.UID }
+			action={ templ.URL("/patients/" + patient.UID + "/patch") }
 		} else {
 			hx-post="/patients"
 			action="/patients"

--- a/internal/views/patientspage_templ.go
+++ b/internal/views/patientspage_templ.go
@@ -168,7 +168,7 @@ func PatientFormPage(patient models.Patient, c *Ctx) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if patient.ID == "" || patient.ID == "new" {
+			if patient.UID == "" || patient.UID == "new" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<h1 class=\"font-bold text-2xl\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -210,9 +210,9 @@ func PatientFormPage(patient models.Patient, c *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var10 templ.SafeURL
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments?patientId=" + patient.ID))
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments?patientId=" + patient.UID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 67, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 67, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -399,9 +399,9 @@ func PatientLi(patient models.Patient, c *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var19 templ.SafeURL
-		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments?patientId=" + patient.ID))
+		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments?patientId=" + patient.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 150, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 150, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -425,9 +425,9 @@ func PatientLi(patient models.Patient, c *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 templ.SafeURL
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/patients/" + patient.ID))
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/patients/" + patient.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 159, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 159, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -480,9 +480,9 @@ func PatientDeleteForm(patient models.Patient, c *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var24 templ.SafeURL
-		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/patients/"+patient.ID) + "/delete")
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/patients/"+patient.UID) + "/delete")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 176, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 176, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
@@ -493,9 +493,9 @@ func PatientDeleteForm(patient models.Patient, c *Ctx) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var25 string
-		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs("/patients/" + patient.ID)
+		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs("/patients/" + patient.UID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 177, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 177, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
@@ -632,9 +632,9 @@ func PatientProfile(patient models.Patient, c *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var33 string
-			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(patient.ID)
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(patient.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 216, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 216, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
@@ -671,7 +671,7 @@ func PatientProfile(patient models.Patient, c *Ctx) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var35 templ.SafeURL
-				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/patients/" + patient.ID + "/removepic"))
+				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/patients/" + patient.UID + "/removepic"))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 226, Col: 69}
 				}
@@ -684,7 +684,7 @@ func PatientProfile(patient models.Patient, c *Ctx) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var36 string
-				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs("/patients/" + patient.ID + "/removepic")
+				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs("/patients/" + patient.UID + "/removepic")
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 227, Col: 62}
 				}
@@ -1064,9 +1064,9 @@ func PatientProfile(patient models.Patient, c *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var60 string
-			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(patient.ID)
+			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(patient.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 342, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 342, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 			if templ_7745c5c3_Err != nil {
@@ -1279,9 +1279,9 @@ func PatientProfile(patient models.Patient, c *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var74 string
-			templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(patient.ID)
+			templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(patient.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 393, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 393, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 			if templ_7745c5c3_Err != nil {
@@ -1474,9 +1474,9 @@ func PatientProfile(patient models.Patient, c *Ctx) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var88 string
-			templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(patient.ID)
+			templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(patient.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 441, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 441, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 			if templ_7745c5c3_Err != nil {
@@ -1672,15 +1672,15 @@ func PatientForm(c *Ctx, patient models.Patient) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if patient.ID != "" && patient.ID != "new" {
+		if patient.UID != "" && patient.UID != "new" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 134, " hx-patch=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var95 string
-			templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs("/patients/" + patient.ID)
+			templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs("/patients/" + patient.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 545, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 545, Col: 40}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 			if templ_7745c5c3_Err != nil {
@@ -1691,9 +1691,9 @@ func PatientForm(c *Ctx, patient models.Patient) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var96 templ.SafeURL
-			templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/patients/" + patient.ID + "/patch"))
+			templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/patients/" + patient.UID + "/patch"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 546, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/patientspage.templ`, Line: 546, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
 			if templ_7745c5c3_Err != nil {

--- a/internal/views/userspage.templ
+++ b/internal/views/userspage.templ
@@ -93,7 +93,7 @@ templ UserLi(c *Ctx, user models.User) {
 				<div class="flex gap-2 z-10 mb-2">
 					<a
 						class="btn btn-outline btn-secondary"
-						href={ templ.URL("/admin/users/" + user.ID) }
+						href={ templ.URL("/admin/users/" + user.UID) }
 						hx-boost="true"
 					>
 						@IconEdit("size-6")
@@ -121,13 +121,13 @@ templ UserEditPage(c *Ctx, user models.User) {
 				class="flex justify-between items-center pb-4 pl-4 sm:pl-0"
 				hx-boost="true"
 			>
-				if user.ID == "" || user.ID == "new" {
+				if user.UID == "" || user.UID == "new" {
 					<h1 class="font-bold text-2xl">{ l(c.Locale, "str.new_user") }</h1>
 				} else {
 					<h1 class="font-bold text-2xl">{ l(c.Locale, "str.my_profile") }</h1>
 				}
 				<a
-					href={ templ.URL("/appointments?userId=" + user.ID) }
+					href={ templ.URL("/appointments?userId=" + user.UID) }
 					class="btn btn-primary btn-sm"
 				>
 					@IconCalendar("")
@@ -147,7 +147,7 @@ templ UserProfile(c *Ctx, user models.User) {
 				<p class="mt-1 text-sm leading-6 text-base-content/60">{ c.l("str.personal_info_desc") }</p>
 			</div>
 			@UserForm(c, user) {
-				<input type="hidden" name="id" value={ user.ID } id="pi_user_id"/>
+				<input type="hidden" name="id" value={ user.UID } id="pi_user_id"/>
 				<div class="px-4 py-6 sm:p-8">
 					<div class="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
 						<div class="col-span-full">
@@ -157,8 +157,8 @@ templ UserProfile(c *Ctx, user models.User) {
 									<figure class="flex flex-col gap-1 items-center" id="avatar_pic">
 										@CmpAvatar(user)
 										<a
-											href={ templ.URL("/users/" + user.ID + "/removepic") }
-											hx-patch={ "/users/" + user.ID + "/removepic" }
+										href={ templ.URL("/users/" + user.UID + "/removepic") }
+										hx-patch={ "/users/" + user.UID + "/removepic" }
 											hx-select="#avatar_pic"
 											hx-swap="outerHTML"
 											hx-target="closest figure"
@@ -249,14 +249,14 @@ templ UserForm(c *Ctx, user models.User) {
 		class="relative bg-base-100 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2"
 		method="POST"
 		enctype="multipart/form-data"
-		if user.ID != "new" {
+		if user.UID != "new" {
 			hx-post="/users"
 			action="/users"
 		}
 		else
 		if c.CurrentUser.Role == models.UserRoleAdmin {
-			hx-patch={ "/users/" + user.ID }
-			action={ templ.URL("/users/" + user.ID + "/patch") }
+			hx-patch={ "/users/" + user.UID }
+			action={ templ.URL("/users/" + user.UID + "/patch") }
 		} else {
 			hx-patch={ "/profile" }
 			action={ templ.URL("/profile") }

--- a/internal/views/userspage_templ.go
+++ b/internal/views/userspage_templ.go
@@ -238,9 +238,9 @@ func UserLi(c *Ctx, user models.User) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var11 templ.SafeURL
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/admin/users/" + user.ID))
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/admin/users/" + user.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 96, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 96, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
@@ -358,7 +358,7 @@ func UserEditPage(c *Ctx, user models.User) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if user.ID == "" || user.ID == "new" {
+			if user.UID == "" || user.UID == "new" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<h1 class=\"font-bold text-2xl\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -400,9 +400,9 @@ func UserEditPage(c *Ctx, user models.User) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var19 templ.SafeURL
-			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments?userId=" + user.ID))
+			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/appointments?userId=" + user.UID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 130, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 130, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
@@ -515,9 +515,9 @@ func UserProfile(c *Ctx, user models.User) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(user.ID)
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(user.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 150, Col: 50}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 150, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -554,7 +554,7 @@ func UserProfile(c *Ctx, user models.User) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var27 templ.SafeURL
-				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/users/" + user.ID + "/removepic"))
+				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/users/" + user.UID + "/removepic"))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 160, Col: 63}
 				}
@@ -567,7 +567,7 @@ func UserProfile(c *Ctx, user models.User) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var28 string
-				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs("/users/" + user.ID + "/removepic")
+				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs("/users/" + user.UID + "/removepic")
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 161, Col: 56}
 				}
@@ -866,7 +866,7 @@ func UserForm(c *Ctx, user models.User) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if user.ID != "new" {
+		if user.UID != "new" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, " hx-post=\"/users\" action=\"/users\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -882,9 +882,9 @@ func UserForm(c *Ctx, user models.User) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var46 string
-			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs("/users/" + user.ID)
+			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs("/users/" + user.UID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 258, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 258, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
@@ -895,9 +895,9 @@ func UserForm(c *Ctx, user models.User) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var47 templ.SafeURL
-			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/users/" + user.ID + "/patch"))
+			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL("/users/" + user.UID + "/patch"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 259, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/views/userspage.templ`, Line: 259, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 			if templ_7745c5c3_Err != nil {

--- a/internal/views/view_test.go
+++ b/internal/views/view_test.go
@@ -43,7 +43,7 @@ func TestNewCtxAndOptions(t *testing.T) {
 	runViewCtx(t, "/ctx?toast=Saved&sub=Done&level=success", func(c fiber.Ctx) {
 		c.Locals("locale", "en-US")
 		c.Locals("theme", "dark")
-		expectedCU := models.User{ID: "usr_1", Email: "u@example.com"}
+		expectedCU := models.User{UID: "usr_1", Email: "u@example.com"}
 		c.Locals("current_user", expectedCU)
 
 		vc, err := NewCtx(c)
@@ -53,7 +53,7 @@ func TestNewCtxAndOptions(t *testing.T) {
 		if vc.Locale != "en-US" || vc.Theme != "dark" {
 			t.Fatalf("unexpected locale/theme: %+v", vc)
 		}
-		if vc.CurrentUser.ID != expectedCU.ID {
+		if vc.CurrentUser.UID != expectedCU.UID {
 			t.Fatalf("unexpected current user: %+v", vc.CurrentUser)
 		}
 		if vc.Toast.Msg != "Saved" || vc.Toast.Level != "success" {
@@ -62,14 +62,14 @@ func TestNewCtxAndOptions(t *testing.T) {
 	})
 
 	runViewCtx(t, "/ctx", func(c fiber.Ctx) {
-		vc, err := NewCtx(c, WithTheme("dark"), WithLocale("en-US"), WithToast("ok", "sub", "info"), WithCurrentUser(models.User{ID: "usr_2"}))
+		vc, err := NewCtx(c, WithTheme("dark"), WithLocale("en-US"), WithToast("ok", "sub", "info"), WithCurrentUser(models.User{UID: "usr_2"}))
 		if err != nil {
 			t.Fatalf("new ctx with options failed: %v", err)
 		}
 		if vc.Theme != "dark" || vc.Locale != "en-US" {
 			t.Fatalf("unexpected option values: %+v", vc)
 		}
-		if vc.Toast.Msg != "ok" || vc.CurrentUser.ID != "usr_2" {
+		if vc.Toast.Msg != "ok" || vc.CurrentUser.UID != "usr_2" {
 			t.Fatalf("unexpected option mapping: %+v", vc)
 		}
 	})

--- a/tests/appointment_handlers_test.go
+++ b/tests/appointment_handlers_test.go
@@ -43,7 +43,7 @@ func TestAppointmentHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method: http.MethodPost,
-			path:   "/appointments/" + appt.ID + "/patch",
+			path:   "/appointments/" + appt.UID + "/patch",
 			accept: "application/json",
 			body: url.Values{
 				"duration": {"30"},
@@ -63,7 +63,7 @@ func TestAppointmentHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:     http.MethodPost,
-			path:       "/appointments/" + appt.ID + "/patch",
+			path:       "/appointments/" + appt.UID + "/patch",
 			authToken:  token,
 			htmx:       true,
 			contentTyp: "application/json",
@@ -102,7 +102,7 @@ func TestAppointmentHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/appointments/" + appt.ID + "/cancel",
+			path:      "/appointments/" + appt.UID + "/cancel",
 			authToken: token,
 			htmx:      true,
 		})
@@ -129,7 +129,7 @@ func TestAppointmentHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/appointments/" + appt.ID + "/complete",
+			path:      "/appointments/" + appt.UID + "/complete",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -211,12 +211,12 @@ func TestAppointmentHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/appointments/" + ownerAppt.ID + "/patch",
+			path:      "/appointments/" + ownerAppt.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
-				"clinicId":  {ownerClinic.ID},
-				"patientId": {ownerPatient.ID},
+				"clinicId":  {ownerClinic.UID},
+				"patientId": {ownerPatient.UID},
 				"duration":  {"30"},
 				"bookedAt":  {time.Now().Add(3 * time.Hour).Format("2006-01-02T15:04")},
 			},
@@ -227,7 +227,7 @@ func TestAppointmentHandlers(t *testing.T) {
 
 		resp, _ = h.doRequest(requestOptions{
 			method:    http.MethodDelete,
-			path:      "/appointments/" + ownerAppt.ID,
+			path:      "/appointments/" + ownerAppt.UID,
 			authToken: token,
 			htmx:      true,
 		})
@@ -240,7 +240,7 @@ func TestAppointmentHandlers(t *testing.T) {
 			t.Fatalf("load owner appointment after cross-user attempts: %v", err)
 		}
 		if unchanged.UserID != owner.ID {
-			t.Fatalf("expected appointment ownership unchanged, got %q", unchanged.UserID)
+			t.Fatalf("expected appointment ownership unchanged, got %d", unchanged.UserID)
 		}
 	})
 }

--- a/tests/auth_handlers_test.go
+++ b/tests/auth_handlers_test.go
@@ -99,7 +99,7 @@ func TestAuthHandlers(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("expected 200 for authenticated protected endpoint, got %d", resp.StatusCode)
 		}
-		if !strings.Contains(body, u.ID) {
+		if !strings.Contains(body, u.UID) {
 			t.Fatalf("expected protected response to include current user id")
 		}
 	})

--- a/tests/clinic_handlers_test.go
+++ b/tests/clinic_handlers_test.go
@@ -44,7 +44,7 @@ func TestClinicHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method: http.MethodPost,
-			path:   "/clinics/" + clinic.ID + "/patch",
+			path:   "/clinics/" + clinic.UID + "/patch",
 			accept: "application/json",
 			body: url.Values{
 				"name": {"Blocked"},
@@ -61,7 +61,7 @@ func TestClinicHandlers(t *testing.T) {
 
 		resp, body := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/clinics/" + clinic.ID + "/patch",
+			path:      "/clinics/" + clinic.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -95,7 +95,7 @@ func TestClinicHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/clinics/" + clinic.ID + "/patch",
+			path:      "/clinics/" + clinic.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -118,7 +118,7 @@ func TestClinicHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/clinics/" + clinic.ID + "/patch",
+			path:      "/clinics/" + clinic.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -156,7 +156,7 @@ func TestClinicHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodDelete,
-			path:      "/clinics/" + clinic.ID,
+			path:      "/clinics/" + clinic.UID,
 			authToken: token,
 			htmx:      true,
 		})
@@ -212,7 +212,7 @@ func TestClinicHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/clinics/" + ownerClinic.ID + "/patch",
+			path:      "/clinics/" + ownerClinic.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -225,7 +225,7 @@ func TestClinicHandlers(t *testing.T) {
 
 		resp, _ = h.doRequest(requestOptions{
 			method:    http.MethodDelete,
-			path:      "/clinics/" + ownerClinic.ID,
+			path:      "/clinics/" + ownerClinic.UID,
 			authToken: token,
 			htmx:      true,
 		})

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -174,7 +174,7 @@ func (h *testHarness) createAuthUser(email, password string, role models.UserRol
 	return u
 }
 
-func (h *testHarness) createPatient(userID string, name string) models.Patient {
+func (h *testHarness) createPatient(userID uint, name string) models.Patient {
 	h.t.Helper()
 
 	p := models.Patient{Name: name, Phone: "555-0100", Age: 30, UserID: userID}
@@ -185,7 +185,7 @@ func (h *testHarness) createPatient(userID string, name string) models.Patient {
 	return p
 }
 
-func (h *testHarness) createClinic(userID string, name string) models.Clinic {
+func (h *testHarness) createClinic(userID uint, name string) models.Clinic {
 	h.t.Helper()
 
 	c := models.Clinic{Name: name, UserID: userID}
@@ -196,7 +196,7 @@ func (h *testHarness) createClinic(userID string, name string) models.Clinic {
 	return c
 }
 
-func (h *testHarness) createAppointment(userID, patientID, clinicID string) models.Appointment {
+func (h *testHarness) createAppointment(userID, patientID, clinicID uint) models.Appointment {
 	h.t.Helper()
 
 	a := models.Appointment{
@@ -220,7 +220,7 @@ func (h *testHarness) createAppointment(userID, patientID, clinicID string) mode
 func (h *testHarness) authToken(user models.User) string {
 	h.t.Helper()
 
-	token, err := auth.JWTCreateToken(h.env, user.Email, user.ID)
+	token, err := auth.JWTCreateToken(h.env, user.Email, user.UID)
 	if err != nil {
 		h.t.Fatalf("create auth token: %v", err)
 	}

--- a/tests/patient_handlers_test.go
+++ b/tests/patient_handlers_test.go
@@ -21,7 +21,7 @@ func TestPatientHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/patients/" + patient.ID + "/patch",
+			path:      "/patients/" + patient.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -52,7 +52,7 @@ func TestPatientHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/patients/" + patient.ID + "/patch",
+			path:      "/patients/" + patient.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -96,7 +96,7 @@ func TestPatientHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:     http.MethodPost,
-			path:       "/patients/" + patient.ID + "/patch",
+			path:       "/patients/" + patient.UID + "/patch",
 			authToken:  token,
 			htmx:       true,
 			contentTyp: "application/json",
@@ -115,7 +115,7 @@ func TestPatientHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/patients/" + patient.ID + "/patch",
+			path:      "/patients/" + patient.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -136,7 +136,7 @@ func TestPatientHandlers(t *testing.T) {
 
 		resp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/patients/" + ownerPatient.ID + "/patch",
+			path:      "/patients/" + ownerPatient.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -151,7 +151,7 @@ func TestPatientHandlers(t *testing.T) {
 
 		resp, _ = h.doRequest(requestOptions{
 			method:    http.MethodDelete,
-			path:      "/patients/" + ownerPatient.ID,
+			path:      "/patients/" + ownerPatient.UID,
 			authToken: token,
 			htmx:      true,
 		})

--- a/tests/regression_routes_test.go
+++ b/tests/regression_routes_test.go
@@ -22,7 +22,7 @@ func TestPatchAndDeleteRoutesForPatientAndAppointment(t *testing.T) {
 
 		patchResp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPatch,
-			path:      "/patients/" + patient.ID,
+			path:      "/patients/" + patient.UID,
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
@@ -45,7 +45,7 @@ func TestPatchAndDeleteRoutesForPatientAndAppointment(t *testing.T) {
 
 		delResp, _ := h.doRequest(requestOptions{
 			method:    http.MethodDelete,
-			path:      "/patients/" + patient.ID,
+			path:      "/patients/" + patient.UID,
 			authToken: token,
 			htmx:      true,
 		})
@@ -66,12 +66,12 @@ func TestPatchAndDeleteRoutesForPatientAndAppointment(t *testing.T) {
 
 		patchResp, _ := h.doRequest(requestOptions{
 			method:    http.MethodPost,
-			path:      "/appointments/" + appt.ID + "/patch",
+			path:      "/appointments/" + appt.UID + "/patch",
 			authToken: token,
 			htmx:      true,
 			body: url.Values{
-				"clinicId":  {clinic.ID},
-				"patientId": {patient.ID},
+				"clinicId":  {clinic.UID},
+				"patientId": {patient.UID},
 				"duration":  {"45"},
 				"bookedAt":  {time.Now().Add(3 * time.Hour).Format("2006-01-02T15:04")},
 			},
@@ -90,7 +90,7 @@ func TestPatchAndDeleteRoutesForPatientAndAppointment(t *testing.T) {
 
 		delResp, _ := h.doRequest(requestOptions{
 			method:    http.MethodDelete,
-			path:      "/appointments/" + appt.ID,
+			path:      "/appointments/" + appt.UID,
 			authToken: token,
 			htmx:      true,
 		})


### PR DESCRIPTION
## Summary
- migrate model identity to integer primary keys while keeping public prefixed UID identifiers for routes/forms and external references
- align services, handlers, views, jobs, and tests so external lookups use UID while internal relations and ownership checks use integer IDs
- rebuild baseline SQLite migrations and FTS trigger steps to match the new schema so `make db/reset`, seeds, tests, and Docker builds work from scratch
- harden local auth session snapshot hydration to persist both internal user ID and UID, and reject zero-ID authenticated users in middleware

## Validation
- `make db/reset`
- `make test`
- `make docker/image`