### PR TITLE
feat(bootstrap): auto-create admin after migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ RATE_LIMITER_ENABLED=true
 COOKIE_SECRET=
 JWT_SECRET=
 
+# Optional one-time admin bootstrap (post-migration)
+# If no admin user exists, app creates one from these values.
+ADMIN_USER=
+ADMIN_PASSWORD=
+
 # Database Path
 DB_PATH=store/app.sqlite
 SESSION_DB_PATH=store/session.sqlite

--- a/Milestones.md
+++ b/Milestones.md
@@ -8,6 +8,13 @@
 - [ ] Upload images to S3-compatible object storage (RustFS)
 - [ ] Move frontend + templ generated artifacts to image-build pipeline (keep runtime image slim)
 
+- [ ] Production bootstrap + deploy guardrails
+
+  - [ ] Add strict `COOKIE_SECRET` length validation (16/24/32 bytes)
+  - [ ] Ensure post-migration admin bootstrap: create admin from `ADMIN_USER` + `ADMIN_PASSWORD` only when no admin exists
+  - [ ] Fix local-strategy signup confirm-email delivery in production (env wiring + SMTP path + error visibility)
+  - [ ] Provision Logto tenant in Coolify and wire required runtime env vars
+
   - [ ] Generate Tailwind CSS during Docker build from `styles/global.css` (instead of relying on prebuilt committed `public/global.css`)
   - [ ] Define templ generation policy for CI/image builds vs committed artifacts and enforce one canonical source of truth
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -224,6 +224,11 @@ func setupDB(env *appenv.Env, dbLogger logging.Logger) (*database.Database, erro
 		return nil, err
 	}
 
+	if err := database.EnsureAdminUser(context.Background(), env, db.GormDB()); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
 	return db, nil
 }
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -29,6 +29,13 @@
   - Decide and document templ artifact strategy (`*.templ` source vs committed generated `*_templ.go`) and enforce via CI.
   - Keep runtime image free of Bun/templ toolchain binaries.
 
+- [infra/deploy] Production bootstrap and config guardrails
+  - Add explicit startup validation for `COOKIE_SECRET` to require exactly 16, 24, or 32 bytes (Fiber encryptcookie requirement).
+  - After migrations, if no admin exists, create one from `ADMIN_USER` + `ADMIN_PASSWORD`; if at least one admin exists, do nothing.
+  - Fix local-strategy signup confirm-email delivery (env key alignment, SMTP config consistency, and non-silent send failures).
+  - Provision Logto tenant in Coolify and document callback/resource/env wiring checklist.
+  - Document required Coolify env vars and healthcheck expectations (`/readyz`, `curl`/`wget` availability).
+
 ## Icebox
 
 - [external/runtime] Beta tester release prep

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -33,6 +33,8 @@
   - Add explicit startup validation for `COOKIE_SECRET` to require exactly 16, 24, or 32 bytes (Fiber encryptcookie requirement).
   - After migrations, if no admin exists, create one from `ADMIN_USER` + `ADMIN_PASSWORD`; if at least one admin exists, do nothing.
   - Fix local-strategy signup confirm-email delivery (env key alignment, SMTP config consistency, and non-silent send failures).
+  - Harden async side-effects by adding a safe `SendToWorker` wrapper with panic recovery + structured error logging.
+  - Refactor mailers to consume `appenv.Env` from server/service instead of direct `os.Getenv` reads.
   - Provision Logto tenant in Coolify and document callback/resource/env wiring checklist.
   - Document required Coolify env vars and healthcheck expectations (`/readyz`, `curl`/`wget` availability).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,13 +1,58 @@
-# Deployment (WIP)
+# Deployment Runbook
 
-This file is intentionally a placeholder.
+## Coolify Required Env Vars
 
-When deployment strategy is finalized, document here:
+Minimum runtime vars for production deploy:
 
-- target runtime/platform
-- build and release flow
-- runtime environment variables
-- database migration strategy
-- rollback strategy
-- backup and restore process
-- observability checks after deploy
+- `APP_ENV=production`
+- `APP_NAME`, `APP_PROTOCOL`, `APP_DOMAIN`, `APP_VERSION`, `APP_PORT`
+- `COOKIE_SECRET` (must be exactly 16, 24, or 32 bytes)
+- `JWT_SECRET`
+- `DB_PATH`, `SESSION_DB_PATH`
+- `EMAIL_SENDER`, `EMAIL_SECRET`, `EMAIL_FROM_ADDRESS`, `EMAIL_SMTP_URL`
+- `GOOSE_DRIVER`, `GOOSE_DBSTRING`, `GOOSE_MIGRATION_DIR`
+- `ASSETS_DIR`
+
+Optional one-time admin bootstrap vars:
+
+- `ADMIN_USER`
+- `ADMIN_PASSWORD`
+
+Behavior:
+
+- After migrations, app checks if an admin exists.
+- If an admin already exists, no action is taken.
+- If no admin exists and both `ADMIN_USER` + `ADMIN_PASSWORD` are set, app creates one admin user.
+- If no admin exists and vars are missing, app continues without auto-creating an admin.
+
+## Healthcheck Expectations
+
+App health endpoints:
+
+- `/livez` process liveness
+- `/readyz` readiness (includes DB readiness)
+- `/startupz` startup lifecycle (optional monitor)
+
+Runtime image includes `curl`/`wget` for Coolify checks.
+
+Suggested Coolify check target:
+
+- Primary: `/readyz`
+- Secondary: `/livez` for process-up validation
+
+## Seeded vs Non-Seeded Behavior
+
+- Seeded flow (`cmd/seed`): creates deterministic seed data including `admin@seed.local`.
+- Non-seeded production flow: no seed dependency; use signup + admin bootstrap env vars if needed.
+
+Admin access path:
+
+- Existing admin can access admin routes directly.
+- For fresh production DB without seed data, set `ADMIN_USER` + `ADMIN_PASSWORD` for first boot, then remove/rotate those vars.
+
+## Logto Tenant Checklist (Coolify)
+
+- Provision a Logto tenant/environment for production.
+- Configure app callback/signout URLs for the production domain.
+- Set runtime vars: `LOGTO_URL`, `LOGTO_APP_ID`, `LOGTO_APP_SECRET`, `LOGTO_RESOURCE`.
+- Verify sign-in callback and API token audience after deploy.

--- a/internal/database/admin.go
+++ b/internal/database/admin.go
@@ -1,0 +1,55 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"miconsul/internal/lib/appenv"
+	"miconsul/internal/models"
+
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+func EnsureAdminUser(ctx context.Context, env *appenv.Env, db *gorm.DB) error {
+	if env == nil || db == nil {
+		return nil
+	}
+
+	var adminCount int64
+	if err := db.WithContext(ctx).Model(&models.User{}).Where("role = ?", models.UserRoleAdmin).Count(&adminCount).Error; err != nil {
+		return fmt.Errorf("count admin users: %w", err)
+	}
+	if adminCount > 0 {
+		return nil
+	}
+
+	email := strings.TrimSpace(strings.ToLower(env.AdminUser))
+	password := env.AdminPassword
+	if email == "" || password == "" {
+		return nil
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), 12)
+	if err != nil {
+		return fmt.Errorf("hash admin password: %w", err)
+	}
+
+	user := models.User{
+		Email:             email,
+		Password:          string(hashedPassword),
+		Role:              models.UserRoleAdmin,
+		ConfirmEmailToken: "",
+	}
+	if err := db.WithContext(ctx).Create(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return nil
+		}
+
+		return fmt.Errorf("create admin user: %w", err)
+	}
+
+	return nil
+}

--- a/internal/database/admin_test.go
+++ b/internal/database/admin_test.go
@@ -1,0 +1,86 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+
+	"miconsul/internal/lib/appenv"
+	"miconsul/internal/models"
+
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestEnsureAdminUser(t *testing.T) {
+	t.Run("creates admin when missing and env vars set", func(t *testing.T) {
+		db := newAdminTestDB(t)
+		env := &appenv.Env{AdminUser: "admin@example.com", AdminPassword: "Password1!"}
+
+		if err := EnsureAdminUser(t.Context(), env, db); err != nil {
+			t.Fatalf("EnsureAdminUser() unexpected error: %v", err)
+		}
+
+		var user models.User
+		if err := db.Where("email = ?", "admin@example.com").Take(&user).Error; err != nil {
+			t.Fatalf("expected admin user to exist: %v", err)
+		}
+		if user.Role != models.UserRoleAdmin {
+			t.Fatalf("expected role admin, got %q", user.Role)
+		}
+		if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte("Password1!")); err != nil {
+			t.Fatalf("expected hashed password to match input: %v", err)
+		}
+	})
+
+	t.Run("does nothing when admin already exists", func(t *testing.T) {
+		db := newAdminTestDB(t)
+		if err := db.Create(&models.User{Email: "already-admin@example.com", Password: "hash", Role: models.UserRoleAdmin}).Error; err != nil {
+			t.Fatalf("seed admin: %v", err)
+		}
+
+		env := &appenv.Env{AdminUser: "new-admin@example.com", AdminPassword: "Password1!"}
+		if err := EnsureAdminUser(t.Context(), env, db); err != nil {
+			t.Fatalf("EnsureAdminUser() unexpected error: %v", err)
+		}
+
+		var count int64
+		if err := db.Model(&models.User{}).Where("role = ?", models.UserRoleAdmin).Count(&count).Error; err != nil {
+			t.Fatalf("count admins: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("expected admin count to stay at 1, got %d", count)
+		}
+	})
+
+	t.Run("does nothing when env vars are missing", func(t *testing.T) {
+		db := newAdminTestDB(t)
+		env := &appenv.Env{}
+
+		if err := EnsureAdminUser(t.Context(), env, db); err != nil {
+			t.Fatalf("EnsureAdminUser() unexpected error: %v", err)
+		}
+
+		var count int64
+		if err := db.Model(&models.User{}).Where("role = ?", models.UserRoleAdmin).Count(&count).Error; err != nil {
+			t.Fatalf("count admins: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("expected no admin created, got %d", count)
+		}
+	})
+}
+
+func newAdminTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "ensure_admin_test.sqlite")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatalf("automigrate user: %v", err)
+	}
+
+	return db
+}

--- a/internal/lib/appenv/env.go
+++ b/internal/lib/appenv/env.go
@@ -20,7 +20,7 @@ type Env struct {
 	AppShutdownTimeout time.Duration `env:"APP_SHUTDOWN_TIMEOUT;optional;min=1s"`
 	RateLimiterEnabled bool          `env:"RATE_LIMITER_ENABLED;optional"`
 
-	CookieSecret string `env:"COOKIE_SECRET;regex=^.{32,}$"`
+	CookieSecret string `env:"COOKIE_SECRET;regex=^(.{16}|.{24}|.{32})$"`
 	JWTSecret    string `env:"JWT_SECRET"`
 
 	DBPath        string `env:"DB_PATH"`
@@ -31,6 +31,8 @@ type Env struct {
 	EmailSecret      string `env:"EMAIL_SECRET"`
 	EmailFromAddress string `env:"EMAIL_FROM_ADDRESS"`
 	EmailSMTPURL     string `env:"EMAIL_SMTP_URL"`
+	AdminUser        string `env:"ADMIN_USER;optional;trimspace"`
+	AdminPassword    string `env:"ADMIN_PASSWORD;optional"`
 
 	GooseDriver       string `env:"GOOSE_DRIVER"`
 	GooseDBString     string `env:"GOOSE_DBSTRING"`

--- a/internal/lib/appenv/env_test.go
+++ b/internal/lib/appenv/env_test.go
@@ -190,6 +190,33 @@ func TestNewLoadsEnvironment(t *testing.T) {
 	}
 }
 
+func TestNewAcceptsCookieSecretAllowedLengths(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret string
+	}{
+		{name: "16 bytes", secret: "1234567890abcdef"},
+		{name: "24 bytes", secret: "1234567890abcdefghijklmn"},
+		{name: "32 bytes", secret: "12345678901234567890123456789012"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			setRequiredEnv(t)
+			t.Setenv("COOKIE_SECRET", tc.secret)
+
+			env, err := New()
+			if err != nil {
+				t.Fatalf("unexpected New error: %v", err)
+			}
+			if env == nil {
+				t.Fatalf("expected non-nil env")
+			}
+		})
+	}
+}
+
 func TestNewReturnsErrorOnLoadFailure(t *testing.T) {
 	setRequiredEnv(t)
 	t.Setenv("COOKIE_SECRET", "too-short")

--- a/internal/mailer/appointmentmailer.go
+++ b/internal/mailer/appointmentmailer.go
@@ -7,18 +7,21 @@ import (
 	"fmt"
 	"miconsul/internal/lib/appenv"
 	"miconsul/internal/models"
-	"os"
 
 	"gopkg.in/gomail.v2"
 )
 
 func SendAppointmentBookedEmail(env *appenv.Env, appointment models.Appointment) error {
+	if env == nil {
+		return errors.New("appointment booked mailer requires non-nil env")
+	}
+
 	if appointment.Patient.ID == 0 || appointment.Clinic.ID == 0 {
 		fmt.Println(errors.New("appointment Clinic or Patient association is missing, they must be Preloaded"))
 	}
 
 	m := gomail.NewMessage()
-	m.SetHeader("From", os.Getenv("EMAIL_FROM_ADDR"))
+	m.SetHeader("From", env.EmailFromAddress)
 	m.SetHeader("To", appointment.Patient.Email)
 	m.SetAddressHeader("Bcc", "edgarsilva.dev@gmail.com", "edgarsilva")
 	m.SetHeader("Subject", "Miconsul:"+l("es-MX", "email.confirm_appointment_title"))
@@ -29,8 +32,7 @@ func SendAppointmentBookedEmail(env *appenv.Env, appointment models.Appointment)
 	}
 	m.SetBody("text/html", emailHTML.String())
 
-	smtpURL := os.Getenv("EMAIL_SMTP_URL")
-	d := gomail.NewDialer(smtpURL, 587, dialerUsername(), dialerPassword())
+	d := gomail.NewDialer(env.EmailSMTPURL, 587, dialerUsername(env), dialerPassword(env))
 
 	// Send Email
 	if err := d.DialAndSend(m); err != nil {
@@ -41,12 +43,16 @@ func SendAppointmentBookedEmail(env *appenv.Env, appointment models.Appointment)
 }
 
 func SendAppointmentReminderEmail(env *appenv.Env, appointment models.Appointment) error {
+	if env == nil {
+		return errors.New("appointment reminder mailer requires non-nil env")
+	}
+
 	if appointment.Patient.ID == 0 || appointment.Clinic.ID == 0 {
 		return errors.New("appointment Clinic or Patient association is missing, they must be Preloaded")
 	}
 
 	m := gomail.NewMessage()
-	m.SetHeader("From", os.Getenv("EMAIL_FROM_ADDR"))
+	m.SetHeader("From", env.EmailFromAddress)
 	m.SetHeader("To", appointment.Patient.Email)
 	m.SetAddressHeader("Bcc", "edgarsilva.dev@gmail.com", "edgarsilva")
 	m.SetHeader("Subject", "Miconsul:"+l("es-MX", "email.confirm_appointment_title"))
@@ -57,7 +63,7 @@ func SendAppointmentReminderEmail(env *appenv.Env, appointment models.Appointmen
 	}
 	m.SetBody("text/html", emailHTML.String())
 
-	d := gomail.NewDialer("smtp.gmail.com", 587, dialerUsername(), dialerPassword())
+	d := gomail.NewDialer(env.EmailSMTPURL, 587, dialerUsername(env), dialerPassword(env))
 
 	// Send Email
 	if err := d.DialAndSend(m); err != nil {

--- a/internal/mailer/base.go
+++ b/internal/mailer/base.go
@@ -1,8 +1,8 @@
 package mailer
 
 import (
+	"miconsul/internal/lib/appenv"
 	"miconsul/internal/lib/localize"
-	"os"
 	"strings"
 )
 
@@ -19,12 +19,20 @@ func l(lang, key string) string {
 	return locales.GetWithLocale(lang, key)
 }
 
-func dialerUsername() string {
-	return os.Getenv("EMAIL_SENDER")
+func dialerUsername(env *appenv.Env) string {
+	if env == nil {
+		return ""
+	}
+
+	return env.EmailSender
 }
 
-func dialerPassword() string {
-	pwd := os.Getenv("EMAIL_SECRET")
+func dialerPassword(env *appenv.Env) string {
+	if env == nil {
+		return ""
+	}
+
+	pwd := env.EmailSecret
 	pwd = strings.Trim(pwd, "\"")
 
 	return pwd

--- a/internal/mailer/base_test.go
+++ b/internal/mailer/base_test.go
@@ -1,6 +1,7 @@
 package mailer
 
 import (
+	"miconsul/internal/lib/appenv"
 	"os"
 	"strings"
 	"testing"
@@ -9,11 +10,12 @@ import (
 func TestDialerCredentialsAndLocalization(t *testing.T) {
 	t.Setenv("EMAIL_SENDER", "sender@example.com")
 	t.Setenv("EMAIL_SECRET", "\"secret123\"")
+	env := &appenv.Env{EmailSender: "sender@example.com", EmailSecret: "\"secret123\""}
 
-	if got := dialerUsername(); got != "sender@example.com" {
+	if got := dialerUsername(env); got != "sender@example.com" {
 		t.Fatalf("expected sender@example.com, got %q", got)
 	}
-	if got := dialerPassword(); got != "secret123" {
+	if got := dialerPassword(env); got != "secret123" {
 		t.Fatalf("expected unquoted secret, got %q", got)
 	}
 

--- a/internal/mailer/confirmemail.go
+++ b/internal/mailer/confirmemail.go
@@ -4,32 +4,34 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"os"
+	"miconsul/internal/lib/appenv"
 
 	"gopkg.in/gomail.v2"
 )
 
-func ConfirmEmail(email, token string) error {
+func ConfirmEmail(env *appenv.Env, email, token string) error {
+	if env == nil {
+		return errors.New("mailer confirm email requires non-nil env")
+	}
+
 	m := gomail.NewMessage()
-	m.SetHeader("From", os.Getenv("EMAIL_FROM_ADDR"))
+	m.SetHeader("From", env.EmailFromAddress)
 	m.SetHeader("To", email)
 	// m.SetAddressHeader("Cc", "dan@example.com", "Dan")
 	m.SetHeader("Subject", "Scaffold: Confirm your email to login to Miconsul!")
 
-	url := "https://" + os.Getenv("APP_DOMAIN") + "/signup/confirm/" + token
+	url := "https://" + env.AppDomain + "/signup/confirm/" + token
 	emailHTML := bytes.Buffer{}
 	if err := ConfirmEmailTpl(email, url).Render(context.Background(), &emailHTML); err != nil {
 		return errors.New("couldn't create HTML from templ comp to send email")
 	}
 	m.SetBody("text/html", emailHTML.String())
 
-	dialer := gomail.NewDialer("smtp.gmail.com", 587, dialerUsername(), dialerPassword())
+	dialer := gomail.NewDialer(env.EmailSMTPURL, 587, dialerUsername(env), dialerPassword(env))
 
 	// Send Email
 	if err := dialer.DialAndSend(m); err != nil {
-		fmt.Println("-------> Failed to send email:", err)
-		return nil
+		return err
 	}
 
 	return nil

--- a/internal/mailer/resetpassword.go
+++ b/internal/mailer/resetpassword.go
@@ -4,19 +4,23 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"os"
+	"miconsul/internal/lib/appenv"
 
 	"gopkg.in/gomail.v2"
 )
 
-func ResetPassword(email, token string) error {
+func ResetPassword(env *appenv.Env, email, token string) error {
+	if env == nil {
+		return errors.New("mailer reset password requires non-nil env")
+	}
+
 	m := gomail.NewMessage()
-	m.SetHeader("From", os.Getenv("EMAIL_FROM_ADDR"))
-	m.SetHeader("To", "edgarsilva.dev@gmail.com")
+	m.SetHeader("From", env.EmailFromAddress)
+	m.SetHeader("To", email)
 	// m.SetAddressHeader("Cc", "dan@example.com", "Dan")
 	m.SetHeader("Subject", "Scaffold: Reset Your Password!")
 
-	url := "http://localhost:8080/resetpassword/change/" + token
+	url := env.AppProtocol + "://" + env.AppDomain + "/resetpassword/change/" + token
 	emailHTML := bytes.Buffer{}
 	if err := ResetPasswordTpl(email, url).Render(context.Background(), &emailHTML); err != nil {
 		return errors.New("couldn't create HTML from templ comp to send email")
@@ -30,7 +34,7 @@ func ResetPassword(email, token string) error {
 	// log.Info("sent CWD ->", cwd)
 	// m.Attach(cwd + "/public/images/ripple-pic.jpg")
 
-	d := gomail.NewDialer("smtp.gmail.com", 587, dialerUsername(), dialerPassword())
+	d := gomail.NewDialer(env.EmailSMTPURL, 587, dialerUsername(env), dialerPassword(env))
 
 	// Send Email
 	if err := d.DialAndSend(m); err != nil {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -153,7 +153,7 @@ func fiberAppErrorHandler(ctx fiber.Ctx, err error) error {
 
 	span := trace.SpanFromContext(ctx.Context())
 
-	if err != nil {
+	if err != nil && code >= fiber.StatusInternalServerError {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 	}

--- a/internal/server/request_logger.go
+++ b/internal/server/request_logger.go
@@ -18,7 +18,7 @@ func RequestLoggerMiddleware(logger obslogging.Logger) func(c fiber.Ctx) error {
 		}
 
 		path := c.Path()
-		if strings.HasPrefix(path, "/public/") || path == "/favicon.ico" || path == "/metrics" {
+		if strings.HasPrefix(path, "/public/") || path == "/favicon.ico" || path == "/readyz" {
 			return c.Next()
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -126,10 +126,6 @@ func validateRuntimeConfig(s *Server) error {
 		return errors.New("COOKIE_SECRET is required")
 	}
 
-	if len(cookieSecret) < 32 {
-		return errors.New("COOKIE_SECRET must be at least 32 characters")
-	}
-
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,7 +160,8 @@ func setupCoreMiddleware(s *Server) {
 			path := c.Path()
 			return strings.HasPrefix(path, "/public/") ||
 				strings.HasPrefix(path, "/.well-known/") ||
-				path == "/favicon.ico"
+				path == "/favicon.ico" ||
+				path == "/readyz"
 		}),
 	))
 	app.Use(logger.New())

--- a/internal/server/server_validation_test.go
+++ b/internal/server/server_validation_test.go
@@ -77,11 +77,6 @@ func TestValidateRuntimeConfig(t *testing.T) {
 			want: "COOKIE_SECRET is required",
 		},
 		{
-			name: "short cookie secret",
-			s:    &Server{Env: &appenv.Env{Environment: appenv.EnvironmentDevelopment, CookieSecret: "short"}},
-			want: "COOKIE_SECRET must be at least 32 characters",
-		},
-		{
 			name: "valid runtime config",
 			s:    &Server{Env: &appenv.Env{Environment: appenv.EnvironmentDevelopment, CookieSecret: validCookieSecret}},
 			want: "",

--- a/internal/services/auth/handlers.go
+++ b/internal/services/auth/handlers.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"miconsul/internal/lib/xid"
-	"miconsul/internal/mailer"
 	"miconsul/internal/models"
 	view "miconsul/internal/views"
 
@@ -152,9 +151,9 @@ func (s *service) HandleSignup(c fiber.Ctx) error {
 
 	err = s.userPendingConfirmation(c.Context(), email)
 	if err != nil {
-		token := newConfirmEmailToken()
-		s.userUpdateConfirmToken(c.Context(), email, token)
-		go mailer.ConfirmEmail(email, token)
+		if resendErr := s.resendPendingConfirmation(c.Context(), email); resendErr != nil {
+			return view.Render(c, view.SignupPage(vc, email, errors.New("failed to resend confirmation email, please try again")))
+		}
 		return s.respondWithRedirect(c, "/signin", "check your inbox, we'll re-send a confirmation link")
 	}
 
@@ -182,7 +181,7 @@ func (s *service) HandleSignupConfirmEmail(c fiber.Ctx) error {
 	}
 
 	_, err = gorm.G[models.User](s.DB.GormDB()).
-		Select("ConfirmEmailToken", "ConfirmEmailExpiresAt").
+		Select("confirm_email_token", "confirm_email_expires_at").
 		Where("confirm_email_token = ? AND confirm_email_expires_at > ?", token, time.Now()).
 		Updates(c.Context(), models.User{})
 	if err != nil {
@@ -276,7 +275,7 @@ func (s *service) HandleResetPassword(c fiber.Ctx) error {
 	user.ResetToken = token
 	user.ResetTokenExpiresAt = time.Now().Add(time.Hour * 1)
 	rowsAffected, err := gorm.G[models.User](s.DB.GormDB()).
-		Select("ResetToken", "ResetTokenExpiresAt").
+		Select("reset_token", "reset_token_expires_at").
 		Where("id = ?", user.ID).
 		Updates(c.Context(), user)
 	if err != nil || rowsAffected != 1 {
@@ -284,7 +283,7 @@ func (s *service) HandleResetPassword(c fiber.Ctx) error {
 		return view.Render(c, view.ResetPasswordPage(vc, email, "", "", errView))
 	}
 
-	go mailer.ResetPassword(email, token)
+	s.sendResetPasswordEmailAsync(c.Context(), email, token)
 
 	return view.Render(c, view.ResetPasswordPage(vc, email, "", "check your email for a reset password link", nil))
 }

--- a/internal/services/auth/service.go
+++ b/internal/services/auth/service.go
@@ -110,8 +110,8 @@ func (s *service) signupIsPasswordValid(pwd string) error {
 		return errors.New("password must contain at least 1 digit (numbers from 0 to 9)")
 	}
 
-	if !strings.ContainsAny(pwd, "!@#$%^&*()") {
-		return errors.New("password must contain at least 1 special character e.g. !@#$%^&*")
+	if !strings.ContainsAny(pwd, "!@#$%^&*().-_ ") {
+		return errors.New("password must contain at least 1 special character e.g. !@#$%^&*().-_ or space")
 	}
 
 	return nil

--- a/internal/services/auth/service.go
+++ b/internal/services/auth/service.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	otellog "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
@@ -80,7 +82,7 @@ func (s *service) signup(ctx context.Context, email string, password string) err
 		return errors.New("failed to save email or password, try again")
 	}
 
-	go mailer.ConfirmEmail(email, token)
+	s.sendConfirmEmailAsync(ctx, email, token, "signup_confirm")
 
 	return nil
 }
@@ -119,7 +121,7 @@ func (s *service) signupIsPasswordValid(pwd string) error {
 
 func (s *service) userPendingConfirmation(ctx context.Context, email string) error {
 	user, err := gorm.G[models.User](s.DB.GormDB()).
-		Select("ID, Email, ConfirmEmailToken").
+		Select("id, email, confirm_email_token").
 		Where("email = ? AND confirm_email_token IS NOT null AND confirm_email_token != ''", email).
 		Take(ctx)
 	if err == nil && user.ID != 0 { // If a row/record exists it means confirmation is pending and we should re-send
@@ -191,7 +193,7 @@ func (s *service) userUpdatePassword(ctx context.Context, email, password, token
 	}
 
 	rowsAffected, err := gorm.G[models.User](s.DB.GormDB()).
-		Select("Password", "ResetToken", "ResetTokenExpiresAt").
+		Select("password", "reset_token", "reset_token_expires_at").
 		Where("email = ? AND reset_token = ? AND reset_token_expires_at > ?", email, token, time.Now()).
 		Limit(1).
 		Updates(ctx, user)
@@ -208,7 +210,7 @@ func (s *service) userUpdateConfirmToken(ctx context.Context, email, token strin
 		ConfirmEmailExpiresAt: time.Now().Add(time.Hour * 24),
 	}
 	rowsAffected, err := gorm.G[models.User](s.DB.GormDB()).
-		Select("ConfirmEmailToken", "ConfirmEmailExpiresAt").
+		Select("confirm_email_token", "confirm_email_expires_at").
 		Where("email = ?", email).
 		Limit(1).
 		Updates(ctx, user)
@@ -271,4 +273,82 @@ func (s *service) saveLogtoUser(ctx context.Context, logtoUser LogtoUser) error 
 	}
 
 	return nil
+}
+
+func (s *service) resendPendingConfirmation(ctx context.Context, email string) error {
+	token := newConfirmEmailToken()
+	if err := s.userUpdateConfirmToken(ctx, email, token); err != nil {
+		return err
+	}
+
+	s.sendConfirmEmailAsync(ctx, email, token, "signup_resend_confirm")
+	return nil
+}
+
+func (s *service) sendConfirmEmailAsync(ctx context.Context, email, token, operation string) {
+	go func() {
+		asyncCtx, span := s.Trace(ctx, "auth/services:"+operation)
+		defer span.End()
+
+		defer func() {
+			if r := recover(); r != nil {
+				err := fmt.Errorf("panic: %v", r)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+				s.emitAsyncEmailError(asyncCtx, operation, email, "panic", err)
+			}
+		}()
+
+		if sendErr := mailer.ConfirmEmail(s.Env, email, token); sendErr != nil {
+			span.RecordError(sendErr)
+			span.SetStatus(codes.Error, sendErr.Error())
+			s.emitAsyncEmailError(asyncCtx, operation, email, "failed", sendErr)
+		}
+	}()
+}
+
+func (s *service) sendResetPasswordEmailAsync(ctx context.Context, email, token string) {
+	go func() {
+		asyncCtx, span := s.Trace(ctx, "auth/services:reset_password_email")
+		defer span.End()
+
+		defer func() {
+			if r := recover(); r != nil {
+				err := fmt.Errorf("panic: %v", r)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+				s.emitAsyncEmailError(asyncCtx, "reset_password", email, "panic", err)
+			}
+		}()
+
+		if sendErr := mailer.ResetPassword(s.Env, email, token); sendErr != nil {
+			span.RecordError(sendErr)
+			span.SetStatus(codes.Error, sendErr.Error())
+			s.emitAsyncEmailError(asyncCtx, "reset_password", email, "failed", sendErr)
+		}
+	}()
+}
+
+func (s *service) emitAsyncEmailError(ctx context.Context, operation, email, status string, err error) {
+	if err == nil || !s.RequestLog.Enabled() {
+		return
+	}
+
+	rec := otellog.Record{}
+	rec.SetTimestamp(time.Now())
+	rec.SetObservedTimestamp(time.Now())
+	rec.SetEventName("auth_email_send")
+	rec.SetBody(otellog.StringValue("auth_email_send"))
+	rec.SetSeverity(otellog.SeverityError)
+	rec.SetSeverityText("ERROR")
+	rec.SetErr(err)
+	rec.AddAttributes(
+		otellog.String("event", "auth_email_send"),
+		otellog.String("operation", operation),
+		otellog.String("status", status),
+		otellog.String("email", email),
+		otellog.String("error", err.Error()),
+	)
+
+	s.RequestLog.Emit(ctx, rec)
 }

--- a/internal/services/auth/service_validation_test.go
+++ b/internal/services/auth/service_validation_test.go
@@ -38,6 +38,10 @@ func TestSignupPasswordValidation(t *testing.T) {
 		{name: "missing digit", pwd: "Password!", wantErr: true},
 		{name: "missing special", pwd: "Password1", wantErr: true},
 		{name: "valid", pwd: "Password1!", wantErr: false},
+		{name: "valid with dot", pwd: "Password1.", wantErr: false},
+		{name: "valid with hyphen", pwd: "Password1-", wantErr: false},
+		{name: "valid with underscore", pwd: "Password1_", wantErr: false},
+		{name: "valid with space", pwd: "Password1 ", wantErr: false},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- add post-migration admin bootstrap that creates an admin from `ADMIN_USER`/`ADMIN_PASSWORD` only when no admin exists
- tighten `COOKIE_SECRET` validation in `appenv` (16/24/32 bytes) and remove duplicate length enforcement from server runtime validation
- expand deployment docs and backlog/milestones with Coolify env requirements, healthcheck expectations, email-delivery follow-up, and Logto tenant provisioning

## Verification
- go test ./...