### PR TITLE
fix(auth): force https callback proto in logto flow

### DIFF
--- a/internal/services/auth/logto_handlers.go
+++ b/internal/services/auth/logto_handlers.go
@@ -79,6 +79,7 @@ func (s *service) HandleLogtoCallback(c fiber.Ctx) error {
 		req.URL.Host = expectedCallback.Host
 		req.URL.Path = expectedCallback.Path
 		req.Host = expectedCallback.Host
+		req.Header.Set("X-Forwarded-Proto", expectedCallback.Scheme)
 	}
 
 	err = logtoClient.HandleSignInCallback(req)

--- a/internal/services/auth/logto_handlers.go
+++ b/internal/services/auth/logto_handlers.go
@@ -75,10 +75,6 @@ func (s *service) HandleLogtoCallback(c fiber.Ctx) error {
 	originalCallbackURL := ""
 	if req.URL != nil {
 		originalCallbackURL = req.URL.String()
-		req.URL.Scheme = expectedCallback.Scheme
-		req.URL.Host = expectedCallback.Host
-		req.URL.Path = expectedCallback.Path
-		req.Host = expectedCallback.Host
 		req.Header.Set("X-Forwarded-Proto", expectedCallback.Scheme)
 	}
 


### PR DESCRIPTION
## Summary
- force `X-Forwarded-Proto` to the expected callback scheme before Logto callback verification
- avoid callback URI mismatch when proxy/tunnel chains incorrectly forward proto as `http`

## Validation
- go test ./internal/services/auth/...