### PR TITLE
chore(middleware): extract jobs UI CSP middleware and tidy handler signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ public/**/*.fiber.*
 
 # Generated local coverage artifacts
 coverage/
+
+# tokei
+.tokeignore

--- a/internal/middleware/authentication.go
+++ b/internal/middleware/authentication.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-func MustAuthenticate(authRuntime auth.Runtime) func(c fiber.Ctx) error {
+func MustAuthenticate(authRuntime auth.Runtime) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		cu, err := auth.Authenticate(c, authRuntime)
 		if err == nil && cu.ID == 0 {
@@ -35,7 +35,7 @@ func MustAuthenticate(authRuntime auth.Runtime) func(c fiber.Ctx) error {
 	}
 }
 
-func MustBeAdmin(authRuntime auth.Runtime) func(c fiber.Ctx) error {
+func MustBeAdmin(authRuntime auth.Runtime) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		cu, err := auth.Authenticate(c, authRuntime)
 		if err == nil && cu.ID == 0 {
@@ -75,7 +75,7 @@ func MustBeAdmin(authRuntime auth.Runtime) func(c fiber.Ctx) error {
 	}
 }
 
-func MaybeAuthenticate(authRuntime auth.Runtime) func(c fiber.Ctx) error {
+func MaybeAuthenticate(authRuntime auth.Runtime) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		cu, _ := auth.Authenticate(c, authRuntime)
 

--- a/internal/middleware/jobsUICS.go
+++ b/internal/middleware/jobsUICS.go
@@ -1,0 +1,12 @@
+package middleware
+
+import (
+	"github.com/gofiber/fiber/v3"
+)
+
+func JobsUICSPMiddleware() fiber.Handler {
+	return func(c fiber.Ctx) error {
+		c.Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'")
+		return c.Next()
+	}
+}

--- a/internal/middleware/locale.go
+++ b/internal/middleware/locale.go
@@ -5,7 +5,7 @@ import (
 )
 
 // LocaleLang defines a universal middleware to stract Locale lang en-US, es-MX, etc
-func LocaleLang() func(c fiber.Ctx) error {
+func LocaleLang() fiber.Handler {
 	return func(c fiber.Ctx) error {
 		lang := ""
 

--- a/internal/middleware/theme.go
+++ b/internal/middleware/theme.go
@@ -4,7 +4,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-func UITheme() func(c fiber.Ctx) error {
+func UITheme() fiber.Handler {
 	return func(c fiber.Ctx) error {
 		theme := c.Cookies("theme", "light")
 		c.Locals("theme", theme)

--- a/internal/routes/router.go
+++ b/internal/routes/router.go
@@ -1,3 +1,5 @@
+// Package routes provides the config for the available routes/endpoint for each service
+// e.g. /api/users, /admin/users, etc.
 package routes
 
 import (
@@ -14,8 +16,6 @@ import (
 	"miconsul/internal/services/patient"
 	"miconsul/internal/services/theme"
 	"miconsul/internal/services/user"
-
-	"github.com/gofiber/fiber/v3"
 )
 
 type routeBootstrap struct {
@@ -47,7 +47,7 @@ func RegisterServices(s *server.Server) error {
 
 	for _, rb := range bootstraps {
 		if err := rb.fn(s, authSvc); err != nil {
-			return fmt.Errorf("bootstrap %s routes: %w", rb.name, err)
+			return fmt.Errorf("failed to bootstrap %s routes: %w", rb.name, err)
 		}
 	}
 
@@ -254,15 +254,8 @@ func AdminRoutes(s *server.Server, authSvc auth.Runtime) error {
 
 	if s.AppEnv().JobsUIEnabled {
 		jobsHandler := jobs.NewMonitorHandler("/admin/jobs", s.AppEnv())
-		a.All("/admin/jobs/*", mw.MustBeAdmin(authSvc), jobsUICSPMiddleware(), jobsHandler)
+		a.All("/admin/jobs/*", mw.MustBeAdmin(authSvc), mw.JobsUICSPMiddleware(), jobsHandler)
 	}
 
 	return nil
-}
-
-func jobsUICSPMiddleware() fiber.Handler {
-	return func(c fiber.Ctx) error {
-		c.Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'")
-		return c.Next()
-	}
 }


### PR DESCRIPTION
## What

Small housekeeping pass on middleware and route bootstrapping.

- **Extract jobs-UI CSP middleware** out of `router.go` into its own `internal/middleware/jobsUICS.go` as an exported `JobsUICSPMiddleware()`, so the routing layer just wires it up via `mw.JobsUICSPMiddleware()`.
- **Tidy middleware constructor signatures**: `MustAuthenticate`, `MustBeAdmin`, `MaybeAuthenticate`, `LocaleLang`, and `UITheme` now return `fiber.Handler` instead of the verbose `func(c fiber.Ctx) error`.
- **routes/router.go**: add a package doc comment, drop the now-unused `fiber` import, and reword the bootstrap error to `failed to bootstrap %s routes`.
- **.gitignore**: ignore the local `.tokeignore` (tokei) file.

## Why

No behavior change — purely a readability/organization cleanup. Moving the CSP middleware next to the other middlewares keeps `router.go` focused on wiring, and the `fiber.Handler` return type reads better and matches Fiber's own conventions.

## Testing

- `go build ./...` passes.