### PR TITLE
refactor(errors): drop redundant "failed to" prefix from wrapped errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,12 @@ This file provides repo-specific guidance for coding assistants working on this 
   - `c.Locals(...)` writes are allowed in middleware auth/session identity binding.
   - `c.Locals(...)` reads are allowed only in `internal/views/ctx.go` and `internal/server/request.go`.
   - Everywhere else should use `s.CurrentUser(c)` and view context APIs instead of reading locals directly.
+- Error handling:
+  - Wrap with `fmt.Errorf("operation: %w", err)` — lowercase, no trailing punctuation, colon separator (Go `ST1005`).
+  - Name the operation/action, not the function (`"enqueue reminder: %w"`, not `"EnqueueReminder -> %w"`); it survives renames and reads as a chain straight to the root cause.
+  - Do not prefix wrapped/internal errors with "failed to" — it is redundant in an `error` and compounds noisily across the wrap chain.
+  - Reserve natural, conversational sentences (`"could not send email, please try again"`) for user-facing messages rendered to templates/HTTP responses — not internal plumbing.
+  - Sentinels: `var ErrX = errors.New("lowercase message")`; compare with `errors.Is` / `errors.As`.
 
 ## templ Guidance Source
 

--- a/internal/jobs/runtime.go
+++ b/internal/jobs/runtime.go
@@ -53,7 +53,7 @@ func New(env *appenv.Env) (*Runtime, error) {
 
 	valkeyConfig, err := valkey.NewConfig(env)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build jobs runtime config: %w", err)
+		return nil, fmt.Errorf("build jobs runtime config: %w", err)
 	}
 
 	redisOpt := asynq.RedisClientOpt{
@@ -147,7 +147,7 @@ func (r *Runtime) RegisterScheduledJob(cronspec string, jobType JobType, payload
 
 	entryID, err := r.scheduler.Register(cronspec, task)
 	if err != nil {
-		return "", fmt.Errorf("failed to register scheduled job %s: %w", jobType, err)
+		return "", fmt.Errorf("register scheduled job %s: %w", jobType, err)
 	}
 	r.registeredSchedules[key] = entryID
 

--- a/internal/lib/appenv/env.go
+++ b/internal/lib/appenv/env.go
@@ -83,12 +83,12 @@ func New() (*Env, error) {
 	}
 	err := simpleenv.Load(env)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load ENV variables: %w", err)
+		return nil, fmt.Errorf("load ENV variables: %w", err)
 	}
 
 	env.AssetsDir, err = normalizeAbsPath(env.AssetsDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to normalize ASSETS_DIR: %w", err)
+		return nil, fmt.Errorf("normalize ASSETS_DIR: %w", err)
 	}
 
 	return env, nil

--- a/internal/lib/workpool/workerpool.go
+++ b/internal/lib/workpool/workerpool.go
@@ -20,7 +20,7 @@ func New(size int) (pool *Pool, shutdownFn func()) {
 
 	p, err := ants.NewPool(size)
 	if err != nil {
-		log.Fatal(fmt.Errorf("failed to initialize worker pool: %w", err))
+		log.Fatal(fmt.Errorf("initialize worker pool: %w", err))
 	}
 
 	pool = &Pool{p: p}

--- a/internal/routes/router.go
+++ b/internal/routes/router.go
@@ -47,7 +47,7 @@ func RegisterServices(s *server.Server) error {
 
 	for _, rb := range bootstraps {
 		if err := rb.fn(s, authSvc); err != nil {
-			return fmt.Errorf("failed to bootstrap %s routes: %w", rb.name, err)
+			return fmt.Errorf("bootstrap %s routes: %w", rb.name, err)
 		}
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -213,7 +213,7 @@ func setupHealthcheckRoutes(s *Server) {
 func WithEnv(env *appenv.Env) ServerOption {
 	return func(server *Server) error {
 		if env == nil {
-			return errors.New("failed to start server without environment config")
+			return errors.New("start server without environment config")
 		}
 
 		server.Env = env
@@ -225,7 +225,7 @@ func WithEnv(env *appenv.Env) ServerOption {
 func WithDatabase(db *database.Database) ServerOption {
 	return func(server *Server) error {
 		if db == nil {
-			return errors.New("failed to start server without Database connection")
+			return errors.New("start server without Database connection")
 		}
 
 		server.DB = db

--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -11,7 +11,7 @@ import (
 // Session retrieves the request session from the configured store.
 func (s *Server) Session(c fiber.Ctx) (*session.Session, error) {
 	if s.SessionStore == nil {
-		err := errors.New("failed to retrieve session: session store is nil")
+		err := errors.New("retrieve session: session store is nil")
 		log.Warn(err.Error())
 		return nil, err
 	}

--- a/internal/services/admin/service.go
+++ b/internal/services/admin/service.go
@@ -99,7 +99,7 @@ func findModelName(modelsDir string, dirEntry fs.DirEntry) (string, error) {
 func resolveModelsDir() (string, error) {
 	_, currentFile, _, ok := runtime.Caller(0)
 	if !ok {
-		return "", errors.New("failed to resolve admin service source path")
+		return "", errors.New("resolve admin service source path")
 	}
 
 	modelsDir := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "../../models"))

--- a/internal/services/auth/jwt.go
+++ b/internal/services/auth/jwt.go
@@ -54,7 +54,7 @@ func decodeJWTToken(env *appenv.Env, tokenStr string) (claims jwt.MapClaims, err
 	tokenJWT, err := jwt.Parse(tokenStr, func(token *jwt.Token) (any, error) { // Don't forget to validate the algorithm is what you expect:
 		// Don't forget to validate the algorithm is what you expect:
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return "", errors.New("failed to jarse JWT token")
+			return "", errors.New("parse JWT token")
 		}
 
 		// hmacSampleSecret is a []byte containing your secret, e.g. []byte("my_secret_key")
@@ -66,12 +66,12 @@ func decodeJWTToken(env *appenv.Env, tokenStr string) (claims jwt.MapClaims, err
 
 	claims, ok := tokenJWT.Claims.(jwt.MapClaims)
 	if !ok {
-		return jwt.MapClaims{}, errors.New("failed to parse JWT token claims")
+		return jwt.MapClaims{}, errors.New("parse JWT token claims")
 	}
 
 	uid, ok := claims["uid"].(string)
 	if !ok || uid == "" {
-		return jwt.MapClaims{}, errors.New("failed to parse JWT token claims, uid not found")
+		return jwt.MapClaims{}, errors.New("parse JWT token claims, uid not found")
 	}
 
 	return claims, nil
@@ -95,7 +95,7 @@ func RefreshJWTToken(env *appenv.Env, token string, claims jwt.MapClaims) (strin
 
 	uid, ok := claims["uid"].(string)
 	if !ok {
-		return "", 0, errors.New("failed to parse JWT token claims, uid not found")
+		return "", 0, errors.New("parse JWT token claims, uid not found")
 	}
 
 	rememberMe := rememberMeFromClaims(claims)

--- a/internal/services/auth/local_strategy.go
+++ b/internal/services/auth/local_strategy.go
@@ -55,7 +55,7 @@ func NewLocalStrategy(resource LocalStrategyResource) *LocalStrategy {
 func (ls LocalStrategy) Authenticate(c fiber.Ctx) (models.User, error) {
 	token := getToken(c)
 	if token == "" {
-		return models.User{}, errors.New("failed to retrieve JWT token, it is blank")
+		return models.User{}, errors.New("retrieve JWT token, it is blank")
 	}
 
 	userFromSession, ok := ls.currentUserFromSession(c, token)
@@ -65,7 +65,7 @@ func (ls LocalStrategy) Authenticate(c fiber.Ctx) (models.User, error) {
 
 	user, err := ls.authenticateWithJWT(c, token)
 	if err != nil {
-		return user, errors.New("failed to authenticate user")
+		return user, errors.New("authenticate user")
 	}
 
 	ls.saveCurrentUserToSession(c, token, user)
@@ -84,7 +84,7 @@ func (ls LocalStrategy) FindUserByID(ctx context.Context, uid string) (models.Us
 func (ls LocalStrategy) authenticateWithJWT(c fiber.Ctx, token string) (models.User, error) {
 	claims, err := decodeJWTToken(ls.resource.AppEnv(), token)
 	if err != nil {
-		return models.User{}, errors.New("failed to validate JWT token")
+		return models.User{}, errors.New("validate JWT token")
 	}
 
 	uid, ok := claims["uid"].(string)
@@ -94,12 +94,12 @@ func (ls LocalStrategy) authenticateWithJWT(c fiber.Ctx, token string) (models.U
 
 	user, err := ls.FindUserByID(c.Context(), uid)
 	if err != nil {
-		return user, errors.New("failed to find user with UID in JWT token")
+		return user, errors.New("find user with UID in JWT token")
 	}
 
 	refreshedJWT, validFor, err := RefreshJWTToken(ls.resource.AppEnv(), token, claims)
 	if err != nil {
-		return user, errors.New("failed to refresh JWT token")
+		return user, errors.New("refresh JWT token")
 	}
 	if refreshedJWT != token {
 		ls.refreshAuthCookie(c, refreshedJWT, validFor)

--- a/internal/services/auth/local_strategy_runtime_test.go
+++ b/internal/services/auth/local_strategy_runtime_test.go
@@ -261,7 +261,7 @@ func TestRuntimeAuthenticateAndTakeUserByExtID(t *testing.T) {
 	t.Run("TakeUserByExtID maps not found to auth error", func(t *testing.T) {
 		svc := newAuthServiceForTests(t)
 		_, err := TakeUserByExtID(context.Background(), svc, "missing")
-		if err == nil || !strings.Contains(err.Error(), "failed to authenticate user") {
+		if err == nil || !strings.Contains(err.Error(), "authenticate user") {
 			t.Fatalf("expected mapped auth error, got %v", err)
 		}
 	})

--- a/internal/services/auth/logto_strategy.go
+++ b/internal/services/auth/logto_strategy.go
@@ -52,7 +52,7 @@ func (lgs *LogtoStrategy) Authenticate(c fiber.Ctx) (models.User, error) {
 
 	user, err := TakeUserByExtID(ctx, lgs.runtime, claims.Sub)
 	if err != nil {
-		return user, errors.New("failed to authenticate user")
+		return user, errors.New("authenticate user")
 	}
 
 	return user, nil

--- a/internal/services/auth/runtime.go
+++ b/internal/services/auth/runtime.go
@@ -65,7 +65,7 @@ func selectAuthenticator(rt Runtime) Authenticator {
 func TakeUserByExtID(ctx context.Context, rt Runtime, extID string) (models.User, error) {
 	user, err := gorm.G[models.User](rt.GormDB()).Where("ext_id = ?", extID).Take(ctx)
 	if err != nil {
-		return models.User{}, errors.New("failed to authenticate user")
+		return models.User{}, errors.New("authenticate user")
 	}
 
 	return user, nil

--- a/internal/services/auth/service.go
+++ b/internal/services/auth/service.go
@@ -194,7 +194,7 @@ func (s *service) authenticateCredentials(ctx context.Context, email, password s
 func (s *service) userUpdatePassword(ctx context.Context, email, password, token string) (models.User, error) {
 	pwd, err := bcrypt.GenerateFromPassword([]byte(password), 12)
 	if err != nil {
-		return models.User{}, errors.New("failed to update password")
+		return models.User{}, errors.New("update password")
 	}
 
 	user := models.User{
@@ -208,7 +208,7 @@ func (s *service) userUpdatePassword(ctx context.Context, email, password, token
 		Limit(1).
 		Updates(ctx, user)
 	if err != nil || rowsAffected != 1 {
-		return models.User{}, errors.New("failed to update password")
+		return models.User{}, errors.New("update password")
 	}
 
 	return user, nil
@@ -225,7 +225,7 @@ func (s *service) userUpdateConfirmToken(ctx context.Context, email, token strin
 		Limit(1).
 		Updates(ctx, user)
 	if err != nil || rowsAffected != 1 {
-		return errors.New("failed to update confirm token")
+		return errors.New("update confirm token")
 	}
 
 	return nil
@@ -249,7 +249,7 @@ func (s *service) saveLogtoUser(ctx context.Context, logtoUser LogtoUser) error 
 
 	user, err := gorm.G[models.User](s.DB.GormDB()).Where("email = ?", logtoUser.Email).Take(ctx)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return fmt.Errorf("failed to load user from logto claims, GORM error: %w", err)
+		return fmt.Errorf("load user from logto claims, GORM error: %w", err)
 	}
 
 	userExists := user.ID != 0
@@ -261,7 +261,7 @@ func (s *service) saveLogtoUser(ctx context.Context, logtoUser LogtoUser) error 
 	if user.Password == "" {
 		rndPwd, err := bcrypt.GenerateFromPassword([]byte(xid.New("rpwd")), 8)
 		if err != nil {
-			return errors.New("failed to generate password placeholder for user")
+			return errors.New("generate password placeholder for user")
 		}
 		user.Password = string(rndPwd)
 	}
@@ -279,7 +279,7 @@ func (s *service) saveLogtoUser(ctx context.Context, logtoUser LogtoUser) error 
 	}
 
 	if result := s.DB.WithContext(ctx).Save(&user); result.Error != nil {
-		return fmt.Errorf("failed to create or update user from logto claims, GORM error: %w", result.Error)
+		return fmt.Errorf("create or update user from logto claims, GORM error: %w", result.Error)
 	}
 
 	return nil

--- a/internal/services/auth/service_behavior_test.go
+++ b/internal/services/auth/service_behavior_test.go
@@ -157,7 +157,7 @@ func TestSaveLogtoUserPaths(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected save error")
 		}
-		if !strings.Contains(err.Error(), "failed to create or update user from logto claims") {
+		if !strings.Contains(err.Error(), "create or update user from logto claims") {
 			t.Fatalf("expected wrapped saveLogtoUser error, got %v", err)
 		}
 	})

--- a/internal/services/clinic/profile_pic.go
+++ b/internal/services/clinic/profile_pic.go
@@ -32,7 +32,7 @@ func SaveProfilePicToDisk(c fiber.Ctx, clinic models.Clinic) (string, error) {
 	profilePath := "/public/assets/profile_pics/" + clinic.UID + "_" + filename
 	err = c.SaveFile(profilePic, "."+profilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to save profilePic to disk: %w", err)
+		return "", fmt.Errorf("save profilePic to disk: %w", err)
 	}
 
 	return profilePath, nil

--- a/internal/services/patient/profile_pic.go
+++ b/internal/services/patient/profile_pic.go
@@ -22,7 +22,7 @@ func SaveProfilePicToDisk(c fiber.Ctx, patient models.Patient, assetsDir string)
 	}
 
 	if patient.UID == "" {
-		return "", errors.New("failed to save profile pic without patient.UID")
+		return "", errors.New("save profile pic without patient.UID")
 	}
 
 	originalFilename := strings.TrimSpace(profilePic.Filename)
@@ -36,12 +36,12 @@ func SaveProfilePicToDisk(c fiber.Ctx, patient models.Patient, assetsDir string)
 	filename := patient.UID + "_ppic_" + safeFilename
 	path, err := ProfilePicPath(filename, assetsDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to save profile pic without an ASSETS_DIR: %w", err)
+		return "", fmt.Errorf("save profile pic without an ASSETS_DIR: %w", err)
 	}
 
 	err = c.SaveFile(profilePic, path)
 	if err != nil {
-		return "", fmt.Errorf("failed to save profilePic to disk: %w", err)
+		return "", fmt.Errorf("save profilePic to disk: %w", err)
 	}
 
 	imgsrc := "/patients/" + patient.UID + "/profilepic/" + filename
@@ -55,12 +55,12 @@ func ProfilePicPath(filename, assetsDir string) (string, error) {
 
 	assetsDir = strings.TrimSpace(assetsDir)
 	if assetsDir == "" {
-		return "", errors.New("failed to find assets directory")
+		return "", errors.New("find assets directory")
 	}
 
 	path := filepath.Join(assetsDir, patientsDir)
 	if err := os.MkdirAll(path, 0o755); err != nil {
-		return "", errors.New("failed to create assets/patients dir")
+		return "", errors.New("create assets/patients dir")
 	}
 
 	return filepath.Join(path, filename), nil
@@ -71,7 +71,7 @@ func profilePicFormFileErr(err error) error {
 		return ErrProfilePicNotProvided
 	}
 
-	return fmt.Errorf("failed to grab profilePic from form: %w", err)
+	return fmt.Errorf("grab profilePic from form: %w", err)
 }
 
 func isMissingProfilePicErr(err error) bool {

--- a/internal/services/user/profile_pic.go
+++ b/internal/services/user/profile_pic.go
@@ -24,19 +24,19 @@ func SaveProfilePicToDisk(c fiber.Ctx, user models.User, assetsDir string) (stri
 	}
 
 	if user.UID == "" {
-		return "", errors.New("failed to save profile pic without user.UID")
+		return "", errors.New("save profile pic without user.UID")
 	}
 
 	filename := user.UID + "_avatar"
 
 	filePath, err := ProfilePicPath(filename, assetsDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to save profile pic without an ASSETS_DIR: %w", err)
+		return "", fmt.Errorf("save profile pic without an ASSETS_DIR: %w", err)
 	}
 
 	err = c.SaveFile(profilePic, filePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to save profilePic to disk: %w", err)
+		return "", fmt.Errorf("save profilePic to disk: %w", err)
 	}
 
 	return "/profile/avatar", nil
@@ -49,7 +49,7 @@ func SaveProfilePicPreviewToTmp(c fiber.Ctx, user models.User, assetsDir string)
 	}
 
 	if user.UID == "" {
-		return "", errors.New("failed to save profile pic preview without user.UID")
+		return "", errors.New("save profile pic preview without user.UID")
 	}
 
 	filename := user.UID + "_preview"
@@ -57,12 +57,12 @@ func SaveProfilePicPreviewToTmp(c fiber.Ctx, user models.User, assetsDir string)
 	// Save tmp preview pic to /tmp directory
 	filePath, err := ProfilePicPath(filename, assetsDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to save profile pic without an ASSETS_DIR: %w", err)
+		return "", fmt.Errorf("save profile pic without an ASSETS_DIR: %w", err)
 	}
 
 	err = c.SaveFile(profilePic, filePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to save profile pic preview to tmp: %w", err)
+		return "", fmt.Errorf("save profile pic preview to tmp: %w", err)
 	}
 
 	return "/profile/avatar/preview", nil
@@ -75,17 +75,17 @@ func ProfilePicPath(filename, assetsDir string) (string, error) {
 
 	assetsDir = strings.TrimSpace(assetsDir)
 	if assetsDir == "" {
-		return "", errors.New("failed to find assets directory")
+		return "", errors.New("find assets directory")
 	}
 
 	absAssetsDir, err := filepath.Abs(assetsDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve assets directory: %w", err)
+		return "", fmt.Errorf("resolve assets directory: %w", err)
 	}
 
 	dirPath := filepath.Join(absAssetsDir, usersDir)
 	if err := os.MkdirAll(dirPath, 0o755); err != nil {
-		return "", errors.New("failed to create assets/users dir")
+		return "", errors.New("create assets/users dir")
 	}
 
 	return filepath.Join(dirPath, filename), nil
@@ -121,7 +121,7 @@ func profilePicFormFileErr(err error) error {
 		return ErrProfilePicNotProvided
 	}
 
-	return fmt.Errorf("failed to grab profilePic from form: %w", err)
+	return fmt.Errorf("grab profilePic from form: %w", err)
 }
 
 func isMissingProfilePicErr(err error) bool {


### PR DESCRIPTION
## Summary

Tidies error messages so wrapped error chains read as an at-a-glance trail to the root cause, and documents the convention so it doesn't creep back. Pure refactor — no behavior change.

Internal/wrapped errors don't need a `failed to` prefix: the value is already an `error`, and the prefix **compounds** across the wrap chain. Compare:

```
failed to handle reminder sweep: failed to load appointments: failed to open sqlite: <root>
handle reminder sweep: load appointments: open sqlite: <root>
```

## What changed

- **Swept ~40 internal error sites** (wrapped `%w` + returned leaf errors) across jobs, server, routes, appenv, workpool, admin, auth, and the profile-pic flows — stripping `failed to ` into a clean imperative operation phrase (`fmt.Errorf("build jobs runtime config: %w", err)`).
- **Fixed a typo** `"failed to jarse JWT token"` → `"parse JWT token"` while editing that line.
- **Updated two test assertions** (`service_behavior_test.go`, `local_strategy_runtime_test.go`) to match the new strings.
- **Documented the convention** in `AGENTS.md` under High-Priority Rules: operation phrase not function name, lowercase, `: %w`, no `failed to`; reserve conversational sentences for user-facing copy.

## Left as-is by design

- **User-facing copy**: toast/redirect/template messages, `apiError` responses, conversational auth errors (`"… please try again"`), and the `errAuthSessionCreate` sentinel.
- **Standalone log lines** (`log.Error/Warn/Printf`, `fmt.Println`) — a single log line doesn't chain, so the prefix isn't redundant there.
- **Enum status constants** (`"failed"`).

## Possible follow-ups (not in this PR)

- Normalizing `failed to` in standalone log statements, if we want full consistency there too.
- A `golangci-lint` config (`stylecheck` ST1005, `errorlint`, `wrapcheck`) to enforce the convention automatically.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...` — all green
- Sanity grep confirms the only remaining `failed to` hits are the deliberately-kept user-facing/conversational/sentinel sites.